### PR TITLE
Cleanups as prep for moving to Unitful

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 ModiaMath
+Unitful

--- a/src/symbolic/symbolic.jl
+++ b/src/symbolic/symbolic.jl
@@ -8,7 +8,7 @@ include("ExactlyRemoveSingularities.jl")
 include("StateSelection.jl")
 
 include("DAEquations/SymbolicTransform.jl")
-include("DAEquations/Basicstructuraltransform.jl")
+include("DAEquations/BasicStructuralTransform.jl")
 
 include("StructuralTransform.jl")
 

--- a/test/TestModelsWithError.jl
+++ b/test/TestModelsWithError.jl
@@ -2,7 +2,6 @@ module TestModelsWithError
 
 using Modia
 using Modia.Electric
-using SIUnits
 
 println("MODELS WITH ERRORS")
 println()

--- a/test/models/TestArrayOfComponents.jl
+++ b/test/models/TestArrayOfComponents.jl
@@ -5,7 +5,6 @@ println("\nTestArrayOfComponents: Demonstrating the handling of arrays of compon
 using Modia
 using Modia.Electric
 using ModiaMath.plot
-using SIUnits
 using Base.Test
 
 @model LPfilter begin

--- a/test/models/TestElectrical.jl
+++ b/test/models/TestElectrical.jl
@@ -3,7 +3,6 @@ module TestElectrical
 using ModiaMath.plot
 using Modia
 using Modia.Electric
-using SIUnits
 using Base.Test
 
 result = simulate(Resistor, 1)

--- a/test/models/TestFilter.jl
+++ b/test/models/TestFilter.jl
@@ -6,7 +6,6 @@ using ModiaMath.plot
 
 using Modia
 using Modia.Electric
-using SIUnits
 
 @model LPfilter begin
   R=Resistor(R=100.0)

--- a/test/runlargetests.jl
+++ b/test/runlargetests.jl
@@ -4,7 +4,6 @@ println("\nRunLargeTest: Demonstrates arrays of components and timing.")
 using Modia
 using Base.Test
 using Modia.Electric
-using SIUnits
 
 @testset "RunLargeTests" begin
 

--- a/test/symbolic/DAEquations/setup.jl
+++ b/test/symbolic/DAEquations/setup.jl
@@ -14,6 +14,6 @@ include("../../../src/symbolic/StateSelection.jl")
 
 include("../../../src/symbolic/DAEquations/Synchronous.jl")
 include("../../../src/symbolic/DAEquations/SymbolicTransform.jl")
-include("../../../src/symbolic/DAEquations/Basicstructuraltransform.jl")
+include("../../../src/symbolic/DAEquations/BasicStructuralTransform.jl")
 
 


### PR DESCRIPTION
This removes some unnecessary instances of `using SIUnits`. Unitful is already included, so it should be in REQUIRE.

I didn't go much further with this in case someone has already done work on the conversion to Unitful. If you want, I can take this conversion to Unitful further.

This PR also includes the capitalization fixes in #7 should be applied first.