### PR TITLE
[WIP] Add dynamic docs generation for Models

### DIFF
--- a/src/language/Instantiation.jl
+++ b/src/language/Instantiation.jl
@@ -26,12 +26,19 @@ using DataStructures.OrderedDict
 @static if VERSION < v"0.7.0-DEV.2005"
   Nothing = Void 
   AbstractDict = Associative
+  macro __MODULE__()
+    return current_module()
+  end
 end
 
 import ModiaMath #0.7
 using Unitful
 using ..ModiaLogging 
 #using ..Synchronous
+
+import Base.Markdown
+import Base.Docs
+
 
 const shortSyntax = true
 
@@ -527,7 +534,7 @@ function code_model(head, top_ex)
     quote
         const $(name) = (let $(this_symbol) = $(quot(This())), $(var_bindings...)
 #            $(quot(Model))($(quot(name)), [$(initializers...)])
-            $(quot(Model))($(quot(name)), [$(args...)], [$(initializers...)])
+            $(quot(Model))($(quot(name)), Modia.Instantiation.@__MODULE__, [$(args...)], [$(initializers...)])
         end)
     end
 end
@@ -615,6 +622,7 @@ A `Model` object is a description on how to fill in an `Instance` object.
 """
 mutable struct Model
     name::Symbol
+    mod::Module
     arguments::Vector
     initializers::Vector{Initializer}
 end
@@ -653,6 +661,8 @@ Instantiations(model::Model) = Instantiations(model, [])
 "Instance of a model, with variable bindings and equations."
 mutable struct Instance
     model_name::Symbol
+    mod::Module
+    info::String
     variables::VariableDict
     equations::Vector{Any}
     partial::Bool
@@ -663,8 +673,8 @@ mutable struct Instance
     F_pre::Vector{Any}
     F_post::Vector{Any}
 end
-function Instance(model_name::Symbol, variables, equations, partial)
-    Instance(model_name, VariableDict(variables), 
+function Instance(model_name::Symbol, mod, info, variables, equations, partial)
+    Instance(model_name, mod, info, VariableDict(variables), 
         collect(Any, equations), partial, [], [], [], [])
 end
 
@@ -760,7 +770,8 @@ end
 
 function instantiate(model::Model, time::Float64, kwargs=[])
     kwargs = Dict(kwargs)
-    instance = Instance(model_name_of(model), VariableDict(), [], :partial in model.arguments)
+    instance = Instance(model_name_of(model), model.mod, get(kwargs, :info, ""), 
+			VariableDict(), [], :partial in model.arguments)
     for initializer in model.initializers
         initialize!(instance, initializer, time, kwargs)
     end
@@ -948,7 +959,7 @@ function flatten(instance::Instance)
         push!(flat.eqs, :($(GetField(This(), name)) = $z) )
     end
 
-    Instance(model_name_of(instance), flat.vars, flat.eqs, instance.partial)
+    Instance(model_name_of(instance), instance.mod, instance.info, flat.vars, flat.eqs, instance.partial)
 end
 
 
@@ -1000,6 +1011,33 @@ function prettyPrint(e::Expr)
         return string(prettyPrint(ex.args[1]), " := ", prettyPrint(ex.args[2]))
     end
     Expr(ex.head, [prettyPrint(arg) for arg in ex.args]...)
+end
+
+
+formatvar(v::Variable) = string("variable : ", v.info, " [", v.typ, "]")
+formatvar(v::Instance) = string("model : ", v.model_name, " : ", v.info)
+formatvar(v) = ""
+
+"Dynamic documentation for Models"
+function Docs.getdoc(m::Model, args = [])
+  docstr = try
+    join(Docs.docstr(Docs.Binding(m.mod, m.name)).text, "\n")
+  catch
+    ""
+  end
+
+  #vars = instantiate(m, 0.0, args).variables
+  vars = instantiate(m, 0.0).variables
+  if length(vars) > 0
+    docstr *= "\n#### Variables\n\n"
+  end
+  for (name, v) in vars
+    docstr *= "* `$name` : "
+    docstr *= formatvar(v)
+    docstr *= "\n"
+  end
+  
+  Markdown.parse(docstr)
 end
 
 

--- a/src/language/Instantiation.jl
+++ b/src/language/Instantiation.jl
@@ -1015,8 +1015,8 @@ end
 
 
 formatvar(v::Variable) = string("variable : ", v.info, " [", v.typ, "]")
-formatvar(v::Instance) = string("model : ", v.model_name, " : ", v.info)
-formatvar(v) = ""
+formatvar(v::Instance) = string("model : ", v.model_name, v.info != "" ? string(" : ", v.info) : "")
+formatvar(v) = string(typeof(v))
 
 "Dynamic documentation for Models"
 function Docs.getdoc(m::Model, args = [])

--- a/src/models/Electric.jl
+++ b/src/models/Electric.jl
@@ -139,7 +139,7 @@ end
 
 @model StepVoltage begin
   V=1u"V"
-  startTime = 0*Seconds
+  startTime = 0u"s"
   t = Var(start=0.0)
   @extends OnePort()
   @inherits v

--- a/src/models/Electric.jl
+++ b/src/models/Electric.jl
@@ -19,8 +19,9 @@ export Pin, Ground, OnePort, Resistor, Capacitor, Inductor,
   ConstantVoltage, StepVoltage, SignalVoltage, SineVoltage, IdealOpAmp3Pin, IdealDiode,
   Voltage, Current, Resistance, Capacitance
 
-Voltage(; args...) = Variable(;T=Unitful.V, size=(), start=0.0, args...)
-Current(; args...) = Variable(;T=Unitful.A, size=(), start=0.0, args...)
+"Electric potential, volts"
+Voltage(; args...) = Variable(;T=Unitful.V, size=(), start=0.0, info="Voltage", args...)
+Current(; args...) = Variable(;T=Unitful.A, size=(), start=0.0, info="Current", args...)
 Resistance(; args...) = Variable(;T=Unitful.Ω, size=(), args...)
 Capacitance(; args...) = Variable(;T=Unitful.F, size=(), args...)
   
@@ -29,13 +30,14 @@ Capacitance(; args...) = Variable(;T=Unitful.F, size=(), args...)
   i=Float(flow=true)
 end 
 
+"An electric node for connections."
 @model Pin begin
-  v=Voltage()
-  i=Current(flow=true)
+  v=Voltage(info = "Voltage of the pin to ground")
+  i=Current(info = "Current into the pin", flow=true)
 end 
 
 @model Ground begin
-  p=Pin()
+  p=Pin(info = "Grounded pin (zero volts)")
 @equations begin
   p.v = 0
   end
@@ -53,13 +55,12 @@ end
   end
 end 
 
+"Base model for an electric device with two `Pin`s."
 @model OnePort begin
-#  v=Voltage()
-#  i=Current()
-  v=Voltage()
-  i=Current()
-  p=Pin()
-  n=Pin()
+  v=Voltage(info = "Voltage between `n` and `p`")
+  i=Current(info = "Current from `p` to `n`")
+  p=Pin(info = "Positive pin")
+  n=Pin(info = "Negative pin")
 @equations begin
   v = p.v - n.v
   0 = p.i + n.i
@@ -67,10 +68,11 @@ end
   end
 end 
 
-@model Resistor begin # Ideal linear electrical resistor
+"Ideal linear electrical resistor"
+@model Resistor begin
+  R = Parameter(start=1.0, info = "Resistance", T=Unitful.V)
   @extends OnePort()
   @inherits i, v
-  R=1 # Parameter(start=1.0) # undefined # Resistance
 @equations begin
   R*i = v
   end
@@ -90,9 +92,9 @@ end
   end
 end 
 
-# Setting state=false for v does not work with extends.
+"Ideal linear electric capacitor."
 @model Capacitor begin
-  @extends OnePort(v=Float(start=0.0))
+  @extends OnePort(v=Float(start=0.0))   # Setting state=false for v does not work with extends.
   @inherits i, v
 #  C=Capacitance() # undefined
   C=undefined

--- a/src/models/Electric.jl
+++ b/src/models/Electric.jl
@@ -70,7 +70,7 @@ end
 
 "Ideal linear electrical resistor"
 @model Resistor begin
-  R = Parameter(start=1.0, info = "Resistance", T=Unitful.V)
+  R = Parameter(start=1.0, info = "Resistance", T=Unitful.Ω)
   @extends OnePort()
   @inherits i, v
 @equations begin


### PR DESCRIPTION
This adds dynamic docs for Models. This is one option for #12. In the example below, all of the information for variables is pulled from the Model, including units.

```julia
julia> using Modia, Modia.Electric

help?> Pin
search: Pin pinv print println pointer print_shortest print_with_color pointer_from_objref sprint @printf isprint @sprintf

  An electric node for connections.

     Variables
    -----------

    •    v : variable : Voltage of the pin to ground [V]
      
    •    i : variable : Current into the pin [A]
      

help?> OnePort
search: OnePort

  Base model for an electric device with two Pins.

     Variables
    -----------

    •    v : variable : Voltage between n and p [V]
      
    •    i : variable : Current from p to n [A]
      
    •    p : model : Pin : Positive pin
      
    •    n : model : Pin : Negative pin
      

help?> Resistor
search: Resistor Resistance

  Ideal linear electrical resistor

     Variables
    -----------

    •    R : variable : Resistance [Ω]
      
    •    v : variable : Voltage between n and p [V]
      
    •    i : variable : Current from p to n [A]
      
    •    p : model : Pin : Positive pin
      
    •    n : model : Pin : Negative pin  
```

To make this work, I added `mod::Module` and  `info::String` fields to `Instance`.

Note that this PR breaks one test. The `Resistor` test breaks. I converted the `R` input to `Resistor` from a constant value to a `Parameter`, so it could include an `info` field. This apparently breaks simulation. I assume this is known as I see other uses of `Parameter()` commented out.