### PR TITLE
Fixes for 1.0.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.6
 PyPlot
+JSON
 ModiaMath
 Unitful
 DataStructures

--- a/src/language/Instantiation.jl
+++ b/src/language/Instantiation.jl
@@ -2,7 +2,7 @@
 Modia module for instantiation and flattening of models.
 
 * Original developer: Toivo Henningsson, Lund
-* Developer: Hilding Elmqvist, Mogram AB  
+* Developer: Hilding Elmqvist, Mogram AB
 * Copyright (c) 2016-2018: Hilding Elmqvist, Toivo Henningsson, Martin Otter
 * License: MIT (expat)
 
@@ -24,13 +24,13 @@ using Base.Meta:quot, isexpr
 using DataStructures: OrderedDict
 #0.7 using SparseArrays
 @static if VERSION < v"0.7.0-DEV.2005"
-  Nothing = Void 
+  Nothing = Void
   AbstractDict = Associative
 end
 
 import ModiaMath #0.7
 using Unitful
-using ..ModiaLogging 
+using ..ModiaLogging
 #using ..Synchronous
 
 const shortSyntax = true
@@ -62,17 +62,17 @@ mutable struct Variable  # {T,n}
     state::Bool
     property::Property
 end
-# The variability, type and info are added as attributes in the type for uniform treatment. 
+# The variability, type and info are added as attributes in the type for uniform treatment.
 # Input/output, etc should also be added.
 
-Variable(;value=nothing, info="", unit=if typeof(value) <: Unitful.Quantity; Unitful.unit(value) else Unitful.NoUnits end, 
-    displayUnit=unit, 
+Variable(;value=nothing, info="", unit=if typeof(value) <: Unitful.Quantity; Unitful.unit(value) else Unitful.NoUnits end,
+    displayUnit=unit,
     min=nothing, max=nothing, start=nothing, fixed::Bool=false, nominal=nothing,
-    variability=continuous, T=if value==nothing; Any else typeof(value) end, size=if value==nothing; nothing else Base.size(value) end, flow::Bool=false, state::Bool=true, property=general) = 
-    Variable(variability, T, size, value, 
+    variability=continuous, T=if value==nothing; Any else typeof(value) end, size=if value==nothing; nothing else Base.size(value) end, flow::Bool=false, state::Bool=true, property=general) =
+    Variable(variability, T, size, value,
     unit, displayUnit, min, max, start, fixed, nominal, info, flow, state, property)
-    
-    
+
+
 
 function Base.show(io::IO, v::Variable)
   print(io, "Variable(")
@@ -125,7 +125,7 @@ function Base.show(io::IO, v::Variable)
   println(io, ")")
 end
 
-#=    
+#=
 function show(io::IO, x::Volt)
     print(io, "Volt")
     nothing
@@ -173,7 +173,7 @@ end
 
 function Base.show(io::IO, g::GetField)
   if shortSyntax
-    print(io, g.base, ".", g.name)  
+    print(io, g.base, ".", g.name)
   else
     print(io, "GetField(", g.base, ", ", g.name, ")")
   end
@@ -181,7 +181,7 @@ end
 
 "AST node for the derivative of a `Symbolic` node."
 struct Der <: Symbolic
-    base::Symbolic    
+    base::Symbolic
 end
 #=
 function Base.show(io::IO, d::Der)
@@ -193,7 +193,7 @@ function Base.show(io::IO, d::Der)
   if shortSyntax
     print(io, "der(", d.base, ")")
   else
-    print(io, "Der(", d.base, ")")  
+    print(io, "Der(", d.base, ")")
   end
 end
 
@@ -202,7 +202,7 @@ struct This <: Symbolic
 end
 
 #=
-function Base.show(io::IO, this::This)    
+function Base.show(io::IO, this::This)
   print(io, "this")
 end
 =#
@@ -211,14 +211,14 @@ function Base.show(io::IO, this::This)
   if shortSyntax
     print(io, "this")
   else
-    print(io, "This()")  
+    print(io, "This()")
   end
 end
 
 "Representation of a connect equation, used in the equations list."
 struct Connect
-    a::Symbolic    
-    b::Symbolic    
+    a::Symbolic
+    b::Symbolic
 end
 
 function Base.show(io::IO, c::Connect)
@@ -308,7 +308,7 @@ function recode(ex::Expr)
             return :( $(quot(Connect))($(recode(args[2])), $(recode(args[3]))) )
         else
             print("The connect statement takes two arguments: $ex")
-        end        
+        end
     end
 
     args = map(recode, ex.args)
@@ -410,7 +410,7 @@ end
 function code_variable(ex::Expr, varnames)
     @assert isexpr(ex, :(=), 2)
     lhs, rhs = ex.args
-    
+
 #    if typeof(rhs) == Expr && (rhs.head == call || rhs.head == :call)
     if typeof(rhs) == Expr && rhs.head == :call
       args = rhs.args
@@ -434,10 +434,10 @@ function code_variable(ex::Expr, varnames)
           rhs = Expr(:call, :Variable, Expr(:kw, :typ, typ), sta, args[2:end]...)
         else
          rhs = Expr(:call, :Variable, Expr(:kw, :typ, typ), args[2:end]...)
-        end          
+        end
       end
     end
-    
+
     rhs = recode_initializer(rhs)
     locals = code_init_locals(varnames)
     fdef = :( ($this_symbol,time)->($locals; $rhs) )
@@ -670,7 +670,7 @@ mutable struct Instance
     F_post::Vector{Any}
 end
 function Instance(model_name::Symbol, variables, equations, partial)
-    Instance(model_name, VariableDict(variables), 
+    Instance(model_name, VariableDict(variables),
         collect(Any, equations), partial, [], [], [], [])
 end
 
@@ -689,7 +689,7 @@ function Base.show(io::IO, inst::Instance)
     end
     println(io, "  ]")
   end
-  
+
   println(io, ")")
 end
 =#
@@ -745,7 +745,7 @@ end
 
 function initialize!(instance::Instance, iv::InitVariable, time::Float64, kwargs::AbstractDict)
 #    @show iv.fdef
-    add_variable!(instance, iv.name, 
+    add_variable!(instance, iv.name,
         as_field_value(haskey(kwargs, iv.name) ? kwargs[iv.name] : iv.init(instance, time),
                        time)
     )
@@ -911,7 +911,7 @@ function to_access(connector::Connection, field::Union{Symbol,Nothing})
 end
 
 function flatten(instance::Instance)
-    flat = Flat(VariableDict(), [], 
+    flat = Flat(VariableDict(), [],
         Dict{Symbol, Symbol}(), Dict{Symbol, Dict}())
     flatten!(flat, "", instance)
 
@@ -990,15 +990,18 @@ function prettyfy(ex::Expr)
     Expr(ex.head, [prettyfy(arg) for arg in ex.args]...)
   end
 end
-      
+
 
 
 # Pretty printing of expressions
-const oper = Base.Operators #; [+, -]]
-#const operator_table = [getfield(oper,name) => name for name in
-#    filter(name->isdefined(oper,name), names(oper))]
-const operator_table = Dict(getfield(oper,name) => name for name in
-    filter(name->isdefined(oper,name), names(oper)))
+const oper = [:!, :(!=), :(!==), :%, :&, :*, :+, :-, :/, ://, :<, :<:, :<<, :(<=),
+               :<|, :(==), :(===), :>, :>:, :(>=), :>>, :>>>, :\, :^, :colon,
+               :ctranspose, :getindex, :hcat, :hvcat, :setindex!, :transpose, :vcat,
+               :xor, :|, :|>, :~, :×, :÷, :∈, :∉, :∋, :∌, :∘, :√, :∛, :∩, :∪, :≠, :≤,
+               :≥, :⊆, :⊈, :⊊, :⊻, :⋅]
+               
+const operator_table = Dict(getfield(Base,name) => name for name in
+    filter(name->isdefined(Base,name), oper))
 
 prettyPrint(ex) = get(operator_table, ex, ex)
 Array{Any}
@@ -1014,4 +1017,4 @@ function prettyPrint(e::Expr)
 end
 
 
-end 
+end

--- a/src/symbolic/Utilities.jl
+++ b/src/symbolic/Utilities.jl
@@ -1,7 +1,7 @@
 """
 Modia module with utility functions.
 
-* Developer: Hilding Elmqvist, Mogram AB  
+* Developer: Hilding Elmqvist, Mogram AB
 * First version: July 2016
 * Copyright (c) 2016-2018: Hilding Elmqvist, Toivo Henningsson, Martin Otter
 * License: MIT (expat)
@@ -15,11 +15,11 @@ using Base.Meta: quot, isexpr
 using Unitful
 using ..Instantiation
 
-using ..ModiaLogging 
+using ..ModiaLogging
 
 export @show_io, printSymbolList, showModel, showInstance, checkSizes, printJSON
 
-using Base.show_unquoted
+using Base: show_unquoted
 
 # Version of @show for any stream
 macro show_io(io, exs...)
@@ -44,14 +44,14 @@ function printSymbolList(label, symbols, numbering=false, vertical=false, A=[])
       if vertical
         loglnModia()
       else
-        logModia(", ") 
+        logModia(", ")
       end
     end
     if numbering
       if vertical
         logModia(lpad(i, 5, " "), ": ")
       else
-        logModia(i, ": ")      
+        logModia(i, ": ")
       end
     end
     if vertical
@@ -59,10 +59,10 @@ function printSymbolList(label, symbols, numbering=false, vertical=false, A=[])
     else
       logModia(prettyfy(symbols[i]))
     end
-    if A !=[] 
+    if A !=[]
       if A[i] != 0
         logModia("A[$i] = $(A[i])")
-      end        
+      end
     end
   end
   if length(symbols) > maxSymbols
@@ -170,10 +170,10 @@ function showInstance(inst, indent="")
   loglnModia("------")
   @show inst
   loglnModia("------")
-=# 
+=#
   newIndent = string(indent, "  ")
   loglnModia("@model ", inst.model_name, " begin")
-  for key in keys(inst.variables) 
+  for key in keys(inst.variables)
     if isa(key, Instance)
       logModia(indent, "  ", key, " = ")
       showInstance(inst.variables[key], newIndent)
@@ -183,7 +183,7 @@ function showInstance(inst, indent="")
       else
         keyname = replace(string(key), "." => "_")
       end
-      logModia(indent, "  ", keyname, " = ") 
+      logModia(indent, "  ", keyname, " = ")
       showVariable(inst.variables[key])
     end
   end
@@ -195,7 +195,7 @@ function showInstance(inst, indent="")
   end
   loglnModia(indent, "  end")
   loglnModia(indent, "end")
- 
+
 end
 
 function checkSizes(VSizes, ESizes)
@@ -209,7 +209,7 @@ function checkSizes(VSizes, ESizes)
   loglnModia()
   scalarV = sum(length(zeros(v)) for v in VSizes)
   scalarE = sum(length(zeros(e)) for e in ESizes)
-  if scalarV != scalarE  
+  if scalarV != scalarE
     error("Scalarized system matrix is not square: $scalarE x $scalarV")
     ok = false
   else
@@ -250,7 +250,7 @@ function printJSON(file, inst::Instance, fullName, name, parent="", indent="", l
   loglnModia(file, indent, "{")
   loglnModia(file, indent, "\"id\": \"$(fullName)\",")
   loglnModia(file, indent, "\"class\": \"$(inst.model_name)\",")
-  
+
   params, unknowns = split_variables(vars_of(inst))
   if length(params) > 0
     loglnModia(file, indent, "\"parameters\": {")
@@ -260,14 +260,14 @@ function printJSON(file, inst::Instance, fullName, name, parent="", indent="", l
       i += 1
       logModia(file, indent1, "\"", n, "\"", " : ", p)
       if i < length(params)
-        loglnModia(file, ",") 
+        loglnModia(file, ",")
       else
-        loglnModia(file) 
+        loglnModia(file)
       end
-    end    
+    end
     loglnModia(file, indent, "},")
   end
-  
+
   loglnModia(file, indent, "\"labels\": [{\"text\": \"$name\"}],")
   if isPort(inst)
     orientation = if length(search(string(parent), "G")) > 0; "\"NORTH\"" elseif length(search(string(name), "p")) > 0 || length(search(string(name), "in")) > 0; "\"WEST\"" else "\"EAST\"" end
@@ -279,12 +279,12 @@ function printJSON(file, inst::Instance, fullName, name, parent="", indent="", l
     loglnModia(file, indent, "\"width\": $size,")
     loglnModia(file, indent, "\"height\": $size")
   end
-  
+
     first = true
     for (n,v) in inst.variables
       if isa(v, Instance) && isPort(v) && level > 1 # length(search(string(n), "n")) == 0
         if first
-          loglnModia(file, indent, ", \"ports\": [")        
+          loglnModia(file, indent, ", \"ports\": [")
         else
           loglnModia(file, indent, ", ")
         end
@@ -295,12 +295,12 @@ function printJSON(file, inst::Instance, fullName, name, parent="", indent="", l
     if ! first
       loglnModia(file, indent, "]")
     end
- 
+
     first = true
     for (n,v) in inst.variables
       if isa(v, Instance) && (! isPort(v) || level == 1) #  || (isa(v, Instance) && isPort(v) && length(search(string(n), "n")) > 0)
         if first
-          loglnModia(file, indent, ", \"children\": [")        
+          loglnModia(file, indent, ", \"children\": [")
         else
           loglnModia(file, indent, ", ")
         end
@@ -311,13 +311,13 @@ function printJSON(file, inst::Instance, fullName, name, parent="", indent="", l
     if ! first
       loglnModia(file, indent, "]")
     end
- 
+
     first = true
     id = 0
     for e in inst.equations
       if isa(e, Connect)
         if first
-          loglnModia(file, indent, ", \"edges\": [") 
+          loglnModia(file, indent, ", \"edges\": [")
         else
           loglnModia(file, indent, ", ")
         end
@@ -328,13 +328,13 @@ function printJSON(file, inst::Instance, fullName, name, parent="", indent="", l
           loglnModia(file, indent, "   \"source\": \"$(e.a.base.name)\",")
           loglnModia(file, indent, "   \"sourcePort\": \"$(string(e.a.base.name)*string(e.a.name))\",")
         else
-          loglnModia(file, indent, "   \"source\": \"$(e.a.name)\",")        
+          loglnModia(file, indent, "   \"source\": \"$(e.a.name)\",")
         end
         if isa(e.b.base, GetField)
           loglnModia(file, indent, "   \"target\": \"$(e.b.base.name)\",")
           loglnModia(file, indent, "   \"targetPort\": \"$(string(e.b.base.name)*string(e.b.name))\"}")
         else
-          loglnModia(file, indent, "   \"target\": \"$(e.b.name)\"}")        
+          loglnModia(file, indent, "   \"target\": \"$(e.b.name)\"}")
         end
       end
     end


### PR DESCRIPTION
I fixed a few things that needed to be fixed in order for `using Modia` to work on a julia 1.0.0: 

* `Base.Operators` is deprecated, instead operators need to be listed [julia/#22251](https://github.com/JuliaLang/julia/pull/22251)
 * `JSON` was missing as a dependency, resulting in an Error/Warning
 * some imports required the `using Base: <function>` syntax instead `using Base.<function>`
 * my editor automatically got rid of a bunch of trailing white-spaces (sorry about that, I hope they weren't dear to anyone), but I can't be bothered to put them back

Since I'm not normally involved with this package, I'd be happy if someone could have a look at this to make sure I didn't f* things up.