### PR TITLE
fixing up symbolic tests for julia 1.0.0

### DIFF
--- a/src/symbolic/DAEquations/SymbolicTransform.jl
+++ b/src/symbolic/DAEquations/SymbolicTransform.jl
@@ -17,6 +17,7 @@ module SymbolicTransform
 using ..Modia
 using ..Instantiation
 import ..Instantiation: GetField, This, Der, Symbolic, time_global, simulationModel_symbol
+import LinearAlgebra
 using Base.Meta: quot, isexpr
 using DataStructures
 using Unitful
@@ -643,7 +644,7 @@ function differentiate(e)
                 diff = Expr(:call, op, diffarg)  
             end
             # @show diff
-        elseif op in [:zeros, zeros, :eye, eye]
+        elseif op in [:zeros, zeros, :eye, LinearAlgebra.I, :identity, identity]
             diff = zero # !!!!
             # diff = Expr(:call, *, e, zero)  # = e*zero
             # diff = zero

--- a/test/symbolic/DAEquations/setup.jl
+++ b/test/symbolic/DAEquations/setup.jl
@@ -1,4 +1,4 @@
-
+import Modia
 import ModiaMath
 
 include("../../../src/language/Instantiation.jl")
@@ -15,5 +15,3 @@ include("../../../src/symbolic/StateSelection.jl")
 include("../../../src/symbolic/DAEquations/Synchronous.jl")
 include("../../../src/symbolic/DAEquations/SymbolicTransform.jl")
 include("../../../src/symbolic/DAEquations/BasicStructuralTransform.jl")
-
-


### PR DESCRIPTION
`eye` is deprecated in favour of `LinearAlgebra.I`, and `Modia` needed to be imported for the tests to work.