### PR TITLE
Fixing some more tests for 1.0

### DIFF
--- a/test/models/TestArrayOfComponents.jl
+++ b/test/models/TestArrayOfComponents.jl
@@ -4,8 +4,8 @@ println("\nTestArrayOfComponents: Demonstrating the handling of arrays of compon
 
 using Modia
 using Modia.Electric
-using ModiaMath.plot
-using Base.Test
+using ModiaMath: plot
+using Test
 
 @model LPfilter begin
     R = Resistor(R=100.0)
@@ -72,7 +72,7 @@ connect(M[i].p, M[i+1].n) for i in 1:size(M)
 # -----------------------------------
 
 # Experimental:
-using Modia.@equation
+using Modia: @equation
 addEquation!(M, e) = begin @show e; push!(M.initializers, Modia.Instantiation.Equations([e])) end
 
 @model LPfilterComponent begin

--- a/test/models/TestElectrical.jl
+++ b/test/models/TestElectrical.jl
@@ -1,6 +1,6 @@
 module TestElectrical
 
-using ModiaMath.plot
+using ModiaMath: plot
 using Modia
 using Modia.Electric
 
@@ -13,7 +13,6 @@ end
 result = simulate(Resistor, 1)
 @test result["i"][end] == 0.0
 @test result["v"][end] == 0.0
-
 
 @model ParallelResistors begin
     R1 = Resistor(R=1, p=Pin(v=Float(start=0.0)), n=Pin(v=Float(start=0.0)))

--- a/test/models/TestEquations.jl
+++ b/test/models/TestEquations.jl
@@ -2,11 +2,12 @@ module TestEquations
 
 #using LinearAlgebra
 using Modia
-using ModiaMath.plot
+using ModiaMath: plot
 
 @static if VERSION < v"0.7.0-DEV.2005"
   using Base.Test
 else
+  using LinearAlgebra: diagm, qr
   using Test
 end
 
@@ -26,8 +27,8 @@ end
         on = time > 1 && time < 3
         s := on ? "on" : "off"
         dummy = if time < 0.00001 || abs(time - 2.0) < 0.01; println("Size of u: ", size(u), " time=", time) else nothing end
-        ((9 + 1) * diagm(1:n) + ones(n, n))^3 * M * diagm(1:n) = eye(n)
-        QR = qr(M)
+        ((9 + 1) * diagm(0=>1:n) + ones(n, n))^3 * M * diagm(0=>1:n) = diagm(0=>ones(n))
+        QR = Tuple{Array,Array}(qr(M))
         Q = QR[1]; R = QR[2]
     end
 end;

--- a/test/models/TestFilter.jl
+++ b/test/models/TestFilter.jl
@@ -4,6 +4,7 @@ println("TestFilter: Tests various features of the symbolic handling.")
 
 using ModiaMath.plot
 
+using Test
 using Modia
 using Modia.Electric
 

--- a/test/models/TestSpatialDiscretization.jl
+++ b/test/models/TestSpatialDiscretization.jl
@@ -1,7 +1,7 @@
 module TestSpatialDiscretization
 
 using Modia
-using ModiaMath.plot
+using ModiaMath: plot
 
 const n = 5
 @model SpatialDiscretization begin
@@ -17,4 +17,3 @@ result = simulate(SpatialDiscretization, 1)
 plot(result, "u")
 
 end
-

--- a/test/models/TestVariableTypes.jl
+++ b/test/models/TestVariableTypes.jl
@@ -133,7 +133,7 @@ const Vec3 = SVector{3,Float64}
         @equations begin
             scalar = 1
             vector = [1.0, 2.0, 3.0]
-            matrix = eye(3, 3)
+            matrix = [1.0  0.0  0.0; 0.0 1.0 0.0; 0.0 0.0 1.0]
             anyVector = [1,2,3]
             v1 = ones(3)
             v2 = ones(3)


### PR DESCRIPTION
Fixes imports, changes how `QR` is called and replaces `eye`.

With these fixes applied, the following tests work:

- `models/TestVariableTypes.jl` &check;
- `models/TestEquations.jl` &check;
- `models/TestElectrical.jl` &cross;
  even the `Resistor` test fails with `LoadError: Translation of model aborted since model not consistent. See log file.`
- `models/TestFilter.jl` all &check; except
  - `LPfilterWithoutGround` &cross;
    (KINSOL problem)
  - `LPfilterAndSineSource` &cross;
    (KINSOL problem)
- `models/TestArrayOfComponents.jl` &check;
- `models/TestSpatialDiscretization.jl` &check;