### PR TITLE
Add docstrings/info for Rotational plus others

### DIFF
--- a/src/language/Instantiation.jl
+++ b/src/language/Instantiation.jl
@@ -47,12 +47,26 @@ const shortSyntax = true
 # Name that should stand for the current instance inside of model declaration
 const this_symbol = :this
 
+"Enum for variability of a variable"
 @enum Variability constant = 1 parameter discrete continuous
+"Indicates a constant valued variable"
+constant
+"Indicates an input value that stays constant with time"
+parameter
+"Indicates a continuous variable"
+continuous
+"Indicates a discrete variable"
+discrete
+
 @enum Property general = 1 symmetric orthogonal rotationGroup3D
+
 
 FLOAT = Union{Float64,AbstractArray{Float64,1},AbstractArray{Float64,2}}
 
-# Constructor for variables in order to support Modelica variable attributes
+
+#"""
+#The main object for a model variable with attributes
+#"""
 mutable struct Variable  # {T,n}
     variability::Variability
     typ
@@ -70,9 +84,31 @@ mutable struct Variable  # {T,n}
     state::Bool
     property::Property
 end
+
+"""
+A constructor for a `Variable`, the main object for a model variable with attributes
+
+## Keyword arguments 
+
+  * `value = undefined`: the value of the Variable
+  * `info = ""`: documentation string
+  * `unit`: unit of measure: defaults to no units unless provided with the `value`
+  * `displayUnit = unit`: unit used for display
+  * `min = undefined`: minimum value
+  * `max = undefined`: maximum value
+  * `start = undefined`: starting value
+  * `fixed::Bool = false`: fixed value
+  * `nominal = undefined`: nominal value
+  * `variability = continuous`: other options include `parameter`, `constant`, or `discrete`
+  * `T`: type of the value; taken from `value`
+  * `size::Tuple = ()`: size of the variable
+  * `flow::Bool = false`: indicates a flow variable for connectors
+  * `state::Bool = true`: indicates a state Variable
+  * `property = general`: other options include `symmetric`, `orthogonal`, and `rotationGroup3D`
+
+"""
 # The variability, type and info are added as attributes in the type for uniform treatment.
 # Input/output, etc should also be added.
-
 Variable(;
     value=nothing, 
     info="", 

--- a/src/models/ModiaBase.jl
+++ b/src/models/ModiaBase.jl
@@ -7,26 +7,41 @@ using Unitful
 using .StructuralTransform
 using .Synchronous: sample, Clock, previous, hold, positive, positiveChange, positiveEdge
 
+"""
+Shortcut for `Variable`
+"""
 Var(; args...) = Variable(; args...)
 
+"""
+Create a floating-point `Variable`
+"""
 Float(value=nothing; info="", size=nothing, unit=NoUnits, displayUnit=NoUnits, 
     min=nothing, max=nothing, start=nothing, fixed::Bool=false, nominal=nothing,
     variability=continuous, 
     flow::Bool=false, state::Bool=true) = Variable(variability, Float64, size, value, 
     unit, displayUnit, min, max, start, fixed, nominal, info, flow, state, general)
 
+"""
+Create a boolean `Variable`
+"""
 Boolean(value=nothing; info="", size=nothing, unit=NoUnits, displayUnit=NoUnits, 
     min=nothing, max=nothing, start=nothing, fixed::Bool=false, nominal=nothing,
     variability=continuous, 
     flow::Bool=false, state::Bool=true) = Variable(variability, Bool, size, value, 
     unit, displayUnit, min, max, start, fixed, nominal, info, flow, state, general)
 
+"""
+Create an integer `Variable`
+"""
 Integ(value=nothing; info="", size=nothing, unit=NoUnits, displayUnit=NoUnits, 
     min=nothing, max=nothing, start=nothing, fixed::Bool=false, nominal=nothing,
     variability=continuous, 
     flow::Bool=false, state::Bool=true) = Variable(variability, Int, size, value, 
     unit, displayUnit, min, max, start, fixed, nominal, info, flow, state, general)
 
+"""
+Create a string `Variable`
+"""
 Str(value=nothing; info="", size=nothing, unit=NoUnits, displayUnit=NoUnits, 
     min=nothing, max=nothing, start=nothing, fixed::Bool=false, nominal=nothing,
     variability=continuous, 
@@ -47,11 +62,21 @@ Str(; args...) = Var(T=String; args...)
 Str0(; args...) = Str(size=(); args...)
 =#
 
+"""
+Create a `Variable` with `parameter` variability, meaning it 
+is an input variable that is constant with time
+"""
 Parameter(; args...) = Variable(variability=parameter; args...)
 Parameter(value; args...) = Variable(variability=parameter, value=value; args...)
 
+"""
+Shortcut for `Parameter`
+"""
 Par(; args...) = Variable(variability=parameter; args...)
 Par(value; args...) = Variable(variability=parameter, value=value; args...)
 
+"""
+A value meant to be filled in later
+"""
 const undefined = nothing
 


### PR DESCRIPTION
This is outside my area of expertise, so keep that in mind when reviewing.

This PR also shows a bit of a naming conflict between models and functions you write to create variables. In this case, I wanted a `Torque()` function to create torque variables. But, there's already a `Torque` that's a model used as a "source". To fix the conflict, I renamed the function to `TorqueVar()`. With multiple dispatch, it may have worked to keep them as the same name, but it would have been confusing.
