### PR TITLE
[Experimental] Solve using the Sundials common DiffEq interface

### DIFF
--- a/src/language/Execution.jl
+++ b/src/language/Execution.jl
@@ -41,8 +41,6 @@ const MODULES = Module[]
 global logTiming               # Show timing for each major task, simulate twice to see effect of compilation time.
 global storeEliminated
 global handleImpulses
-const MOD = Module()
-@show MOD
 
 function setOptions(options) 
     global storeEliminated = true
@@ -514,7 +512,6 @@ function prepare_ida(instance::Instance, first_F_args, initial_bindings::Abstrac
         @show F_code
     end
 
-        @show F_code
     # F = Eval(F_code)
     push!(MODULES, Module())
     index_Module_F = length(MODULES)


### PR DESCRIPTION
This is an experiment to see how hard it would be to convert to the common interface for Sundials. Supporting the DiffEq interface has a number of advantages:

* Plotting comes for free as we'll get the recipes for Plots.
* We also get nice output support from DiffEq.
* It'd be easy to plug in different solvers.

The current version of this PR solves basic models using IDA. The limitations are:

- It doesn't use KLU.
- It doesn't use a Jacobian.
- Events are not triggered. I tried some code to interface this, but it doesn't work. Some more rework will be needed there.
- Tests fail because I made no attempt to make the output compatible with the ModiaMath output.

The best way to make this interface is probably as part of ModiaMath. It was just easiest to do it here as an experiment.

If we go this route, some extra features would be nice on the DiffEq side:

* Support for better annotation metadata. Modia outputs can have a name, units, and an info string. It would be nice to be able to select by name and display results with units.
* It would be nice to have Plots (or Makie) recipes support these annotations.

cc @ChrisRackauckas @MartinOtter