### PR TITLE
Trigger error message in case equation/variable count is wrong

### DIFF
--- a/src/symbolic/DAEquations/BasicStructuralTransform.jl
+++ b/src/symbolic/DAEquations/BasicStructuralTransform.jl
@@ -980,6 +980,19 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
     
     unassignedNames = [] # unknownsNames[unAssignedVariables]
   
+    # Check number of variables
+    variableEquationDifference = length(IG) + length(realStates) - length(assignIG)
+    if variableEquationDifference != 0
+       error("\nThe number of equations and the number of unknowns/states does not match.",
+             "\n   Number of equations: ", length(IG),
+             "\n   Number of variables: ", length(assignIG),
+             "\n   Number of continuous states: ", length(realStates),
+             "\nNote: Number of equations + Number of variables + Number of continuous states must be zero.",
+             variableEquationDifference > 0 ?
+                 "\nIt might be that " * string(variableEquationDifference) * " states must be defined to be non-states" *
+                 "\n(note, Modia does not yet support automatic state selection)." : "")
+    end
+
     if logStatistics
         println("Number of equations: ", length(IG))
         println("Number of variables: ", length(assignIG))

--- a/src/symbolic/DAEquations/BasicStructuralTransform.jl
+++ b/src/symbolic/DAEquations/BasicStructuralTransform.jl
@@ -987,7 +987,7 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
              "\n   Number of equations: ", length(IG),
              "\n   Number of variables: ", length(assignIG),
              "\n   Number of continuous states: ", length(realStates),
-             "\nNote: Number of equations + Number of variables + Number of continuous states must be zero.",
+             "\nNote: Number of equations - Number of variables + Number of continuous states must be zero.",
              variableEquationDifference > 0 ?
                  "\nIt might be that " * string(variableEquationDifference) * " states must be defined to be non-states" *
                  "\n(note, Modia does not yet support automatic state selection)." : "")


### PR DESCRIPTION
In case equation/variable count is wrong, the following type of error message is triggered:
```
The number of equations and the number of unknowns/states does not match.
   Number of equations: 63
   Number of variables: 64
   Number of continuous states: 4
Note: Number of equations - Number of variables + Number of continuous states must be zero.
It might be that 3 states must be defined to be non-states
(note, Modia does not yet support automatic state selection).
```