### PR TITLE
Remove println call with syntax error

### DIFF
--- a/src/symbolic/DAEquations/BasicStructuralTransform.jl
+++ b/src/symbolic/DAEquations/BasicStructuralTransform.jl
@@ -1,7 +1,7 @@
 """
 Module for structural analysis of models.
 
-* Developer: Hilding Elmqvist, Mogram AB  
+* Developer: Hilding Elmqvist, Mogram AB
 * First version: July-August 2016
 * Copyright (c) 2016-2019: Hilding Elmqvist, Toivo Henningsson, Martin Otter
 * License: MIT (expat)
@@ -51,7 +51,7 @@ export analyzeStructurally, basicTransformStructurally, setOptions
 # For function FDAE
 #import Modia
 #using MultiBody
-    
+
 const log = false
 const logIndexReduction = false
 global useIncidenceMatrix = false
@@ -79,9 +79,9 @@ const indexReduction = true
 @show newStateSelection
 @show logFDAE
 @show useKinsol
-=#  
+=#
 
-function setOptions(options) 
+function setOptions(options)
     global removeSingularities = removeSingularitiesDefault
     if haskey(options, :removeSingularities)
         global removeSingularities = options[:removeSingularities]
@@ -109,28 +109,28 @@ function setOptions(options)
         @show expandArrayIncidence
         delete!(options, :expandArrayIncidence)
     end
-    
+
     global useIncidenceMatrix = false
     if haskey(options, :useIncidenceMatrix)
         global useIncidenceMatrix = options[:useIncidenceMatrix]
         @show useIncidenceMatrix
         delete!(options, :useIncidenceMatrix)
     end
-    
+
     global newStateSelection = false
     if haskey(options, :newStateSelection)
         global newStateSelection = options[:newStateSelection]
         @show newStateSelection
         delete!(options, :newStateSelection)
     end
-    
+
     global useKinsol = false
     if haskey(options, :useKinsol)
         global useKinsol = options[:useKinsol]
         @show useKinsol
         delete!(options, :useKinsol)
     end
-    
+
     global logStatistics = true
     if haskey(options, :logStatistics)
         global logStatistics = options[:logStatistics]
@@ -169,8 +169,8 @@ function mult(e1, e2)
         return zero
     elseif e1 == one
         return e2
-    elseif e2 == one 
-        return e1  
+    elseif e2 == one
+        return e1
     else
         Expr(:call, *, e1, e2)
     end
@@ -181,8 +181,8 @@ end
 findVariables!(variables, states, deriv::Vector, ex) = nothing
 # findVariables!(variables, states, deriv::Vector, der::Der) = (push!(states, der.base); push!(deriv, der); nothing)
 findVariables!(variables, states, deriv::Vector, s::Symbol) = (
-    # if ! (s in [:m, :s, :kg, :N]); 
-    push!(variables, s); 
+    # if ! (s in [:m, :s, :kg, :N]);
+    push!(variables, s);
     if s == :.; push!(variables, s.args[1]); push!(states, s.args[1]); push!(deriv, s.args[2].value) end; nothing)
 
   function findVariables!(variables, states, deriv::Vector, ex::Expr)
@@ -192,8 +192,8 @@ findVariables!(variables, states, deriv::Vector, s::Symbol) = (
         # Skip symbols in units on negative numeric literals, eg -2[m/s]
     elseif isexpr(ex, :call)
         if ex.args[1] == :der
-            push!(variables, ex.args[2]); 
-            push!(states, ex.args[2]); 
+            push!(variables, ex.args[2]);
+            push!(states, ex.args[2]);
             push!(deriv, ex)
         else
             for arg in ex.args[2:end]  # skip operator name
@@ -212,7 +212,7 @@ findVariables!(variables, states, deriv::Vector, s::Symbol) = (
             if !(l in omit)
                 push!(variables, l)
             end
-        end      
+        end
     else !isexpr(ex, :quote)
         for arg in ex.args
             findVariables!(variables, states, deriv, arg)
@@ -228,12 +228,12 @@ findIncidence!(incidence::Array{Any,1}, s::Symbol) = (push!(incidence, s); nothi
 # findIncidence!(incidence::Array{Any,1}, get::GetField) = (push!(incidence, get.name); nothing)
 function findIncidence!(incidence::Array{Any,1}, ex::Expr)
     if !isexpr(ex, :quote)
-        if ex.head == :call 
+        if ex.head == :call
             if ex.args[1] == hide
             elseif ex.args[1] == Synchronous.previous
                 for arg in ex.args[2:end]
                     findIncidence!(incidence, arg)
-                end        
+                end
             elseif ex.args[1] == :der
                 push!(incidence, ex)
             else
@@ -249,12 +249,12 @@ function findIncidence!(incidence::Array{Any,1}, ex::Expr)
     end
     nothing
 end
-  
+
 function collectIncidence!(equnr, orgEqu, incidenceMatrix, G, DAEvariables, assigned, assignedv)
     # @show assignedv
-    for v in G[equnr] 
+    for v in G[equnr]
         # @show G[equnr]
-        if v == assignedv 
+        if v == assignedv
         elseif v in DAEvariables
             incidenceMatrix[orgEqu, v] = true
         else
@@ -263,7 +263,7 @@ function collectIncidence!(equnr, orgEqu, incidenceMatrix, G, DAEvariables, assi
     end
 end
 
-findCoefficients!(coefficients, nonLinear, ex) = nonLinear 
+findCoefficients!(coefficients, nonLinear, ex) = nonLinear
 findCoefficients!(coefficients, nonLinear, ex::Int64) = (coefficients[:1] = ex; nonLinear)
 findCoefficients!(coefficients, nonLinear, ex::Float64) = true
 findCoefficients!(coefficients, nonLinear, der::Der) = (coefficients[der] = 1; nonLinear)
@@ -274,19 +274,19 @@ function findCoefficients!(coefficients, nonLinear, ex::Expr)
         if ex.head in [:(=)]
             for iarg in 1:length(ex.args)
                 minus = iarg > 1
-                arg = ex.args[iarg]      
+                arg = ex.args[iarg]
                 coeff = Dict()
                 nonLinear = findCoefficients!(coeff, nonLinear, arg) || nonLinear
                 for v in keys(coeff)
                     if !minus
                         if !haskey(coefficients, v)
-                            coefficients[v] = coeff[v]          
+                            coefficients[v] = coeff[v]
                         else
                             coefficients[v] += coeff[v]
                         end
                     else
                         if !haskey(coefficients, v)
-                            coefficients[v] = -coeff[v]          
+                            coefficients[v] = -coeff[v]
                         else
                             coefficients[v] -= coeff[v]
                         end
@@ -296,16 +296,16 @@ function findCoefficients!(coefficients, nonLinear, ex::Expr)
         elseif ex.head == :call
             if ex.args[1] in [+, :+]
                 for iarg in 2:length(ex.args)
-                    arg = ex.args[iarg]      
+                    arg = ex.args[iarg]
                     coeff = Dict()
                     nonLinear =  findCoefficients!(coeff, nonLinear, arg) || nonLinear
-        
+
                     if coefficients == nothing || coeff == nothing
                         coefficients = nothing
                     else
                         for v in keys(coeff)
                             if !haskey(coefficients, v)
-                                coefficients[v] = coeff[v]          
+                                coefficients[v] = coeff[v]
                             else
                                 coefficients[v] += coeff[v]
                             end
@@ -315,23 +315,23 @@ function findCoefficients!(coefficients, nonLinear, ex::Expr)
             elseif ex.args[1] in [-, :-]
                 for iarg in 2:length(ex.args)
                     minus = length(ex.args) == 2 || iarg > 2
-                    arg = ex.args[iarg]      
+                    arg = ex.args[iarg]
                     coeff = Dict()
                     nonLinear = findCoefficients!(coeff, nonLinear, arg) || nonLinear
-        
+
                     if coefficients == nothing || coeff == nothing
                         coefficients = nothing
                     else
                         for v in keys(coeff)
                             if !minus
                                 if !haskey(coefficients, v)
-                                    coefficients[v] = coeff[v]          
+                                    coefficients[v] = coeff[v]
                                 else
                                     coefficients[v] += coeff[v]
                                 end
                             else
                                 if !haskey(coefficients, v)
-                                    coefficients[v] = -coeff[v]          
+                                    coefficients[v] = -coeff[v]
                                 else
                                     coefficients[v] -= coeff[v]
                                 end
@@ -341,24 +341,24 @@ function findCoefficients!(coefficients, nonLinear, ex::Expr)
                 end
             elseif ex.args[1] in [*, :*] && length(ex.args) == 3
                 if typeof(ex.args[2]) == Int64
-                    arg = ex.args[3]      
+                    arg = ex.args[3]
                     coeff = Dict()
                     nonLinear = findCoefficients!(coeff, nonLinear, arg) || nonLinear
-        
+
                     for v in keys(coeff)
                         if !haskey(coefficients, v)
-                            coefficients[v] = ex.args[2] * coeff[v]          
+                            coefficients[v] = ex.args[2] * coeff[v]
                         else
                             coefficients[v] += ex.args[2] * coeff[v]
                         end
                     end
                 elseif typeof(ex.args[3]) == Int64
-                    arg = ex.args[2]      
+                    arg = ex.args[2]
                     coeff = Dict()
                     nonLinear = findCoefficients!(coeff, nonLinear, arg) || nonLinear
                     for v in keys(coeff)
                         if !haskey(coefficients, v)
-                            coefficients[v] = ex.args[3] * coeff[v]          
+                            coefficients[v] = ex.args[3] * coeff[v]
                         else
                             coefficients[v] += ex.args[3] * coeff[v]
                         end
@@ -368,12 +368,12 @@ function findCoefficients!(coefficients, nonLinear, ex::Expr)
                 end
             else
                 nonLinear = true
-            end  
+            end
         elseif ex.head == :block
             for arg in ex.args
                 coeff = Dict()
                 nonLinear = findCoefficients!(coeff, nonLinear, arg) || nonLinear
-            end      
+            end
         end
     end
     nonLinear
@@ -425,9 +425,9 @@ end
 @enum D undefined = 1 F T
 
 mutable struct Status
-    statusV::OrderedDict{Int64,D} 
-    statusG::OrderedDict{Int64,D} 
-    statusE::OrderedDict{Int64,D} 
+    statusV::OrderedDict{Int64,D}
+    statusG::OrderedDict{Int64,D}
+    statusE::OrderedDict{Int64,D}
 end
 
 function setVariable!(subsValues, v, val)
@@ -445,7 +445,7 @@ function evalArray(subsValues, vec)
 end
 
 substituteDer(ex) = ex
-function substituteDer(ex::Der) 
+function substituteDer(ex::Der)
     :((next($(ex.base)) - $(ex.base)) / delta)
 end
 
@@ -458,7 +458,7 @@ function substituteDer(ex::Expr)
 end
 
 substituteShift(ex) = ex
-function substituteShift(ex::GetField) 
+function substituteShift(ex::GetField)
     :((next($(ex.name))))
 end
 
@@ -506,7 +506,7 @@ function handleSingularities(coefficients, notLinearVariables, unknowns_indices,
     for i in 1:length(Avar)
         if Avar[i] != 0
             j = findfirst(isequal(names[i]), linearVars)
-            if j != notFound 
+            if j != notFound
                 push!(ix, j)
             end
         end
@@ -517,7 +517,7 @@ function handleSingularities(coefficients, notLinearVariables, unknowns_indices,
     if log
         @show notLinearVariableNames
     end
-    
+
     # Build iy, don't include derivatives or potential states
     iy = [i for i in 1:length(linearVars)]
     for v in notLinearVariableNames
@@ -527,7 +527,7 @@ function handleSingularities(coefficients, notLinearVariables, unknowns_indices,
         end
     end
     iy = setdiff(iy, ix)
-    
+
     if log
         @show linearCoefficientMatrix ix iy
     end
@@ -536,13 +536,13 @@ function handleSingularities(coefficients, notLinearVariables, unknowns_indices,
         @time result = ExactlyRemoveSingularities.removeSingularities(linearCoefficientMatrix, ix, iy)
     else
         result = ExactlyRemoveSingularities.removeSingularities(linearCoefficientMatrix, ix, iy)
-    end      
+    end
 
     (iya, eqr, ix1, ix2, eqx, A1, A2) = result
 
-    if log 
+    if log
         @show iya eqr ix1 ix2 eqx A1 A2
-        printRemoveSingularities(linearCoefficientMatrix, result, linearVarsStrings)   
+        printRemoveSingularities(linearCoefficientMatrix, result, linearVarsStrings)
     end
 
     # Remove redundant equations and constraint equations
@@ -562,16 +562,16 @@ function handleSingularities(coefficients, notLinearVariables, unknowns_indices,
             push!(newG, g)
             push!(newGsolvable, Gsolvable[i])
             push!(newESizes, ESizes[i])
-        else 
+        else
             loglnModia("Removed equation: ", prettyPrint(e))
             equationsUpdated = true
         end
-    end    
+    end
 
-    # Add additional equation to set undefined variables 
+    # Add additional equation to set undefined variables
     for i in iya
         eq = :($(GetField(This(), Symbol(linearVarsStrings[i]))) = 0)
-        loglnModia("Added equation: ", prettyPrint(eq))   
+        loglnModia("Added equation: ", prettyPrint(eq))
         equationsUpdated = true
         push!(newEquations, eq)
         push!(newG, [findfirst(isequal(linearVars[i]), names)])
@@ -584,7 +584,7 @@ function handleSingularities(coefficients, notLinearVariables, unknowns_indices,
         e1 = zero
         e2 = zero
         g = []
-    
+
         for j in 1:size(A1, 2)
             e1 = add(e1, mult(A1[i,j], GetField(This(), Symbol(linearVarsStrings[ix1[j]]))))
             push!(g, findfirst(isequal(linearVars[ix1[j]]), names))
@@ -596,16 +596,16 @@ function handleSingularities(coefficients, notLinearVariables, unknowns_indices,
                 if !(states[k] in nonStateVariables)
                     push!(statesIndices, [unknowns_indices[states[k].name]])
                 end
-            end 
+            end
         end
-    
+
         for j in 1:size(A2, 2)
             e2 = add(e2, mult(A2[i,j], GetField(This(), Symbol(linearVarsStrings[ix2[j]]))))
             push!(g, findfirst(isequal(linearVars[ix2[j]]), names))
         end
-    
+
         eq = :($e1 + $e2 = 0.0)
-        loglnModia("Added equation: ", prettyPrint(eq))   
+        loglnModia("Added equation: ", prettyPrint(eq))
         push!(newEquations, eq)
         push!(newG, g)
         push!(newGsolvable, [])
@@ -626,7 +626,7 @@ function handleSingularities(coefficients, notLinearVariables, unknowns_indices,
         end
     end
     return equations, G, Gsolvable, ESizes, nonStateVariables
-end  
+end
 
 
 # ---------------------------
@@ -649,11 +649,11 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
         if DebugPrintAssign loglnModia("\nequation ", neq, ": ", prettyPrint(eq)) end
         incidence = Array{Any,1}()
         findIncidence!(incidence, eq)
-        if DebugPrintAssign 
-            # loglnModia("incidence = ", incidence) 
-            printSymbolList("incidence", incidence)  
+        if DebugPrintAssign
+            # loglnModia("incidence = ", incidence)
+            printSymbolList("incidence", incidence)
         end
-    
+
         vertices = []
         for inc in incidence
             i = get(unknowns_indices, inc, 0)
@@ -663,24 +663,24 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
                     i = i + length(unknownsNames)
                 end
             end
-            if i != notFound 
+            if i != notFound
                 push!(vertices, i)
             end
         end
 
         vertices = unique(vertices)
-        
-        if DebugPrintAssign 
+
+        if DebugPrintAssign
             loglnModia("vertices = ", vertices)
         end
         push!(G, vertices)
-    
+
         if removeSingularities || tearing || automaticStateSelection
-            # Find linear equations with integer coefficients without offset.    
-            coeff = Dict() 
+            # Find linear equations with integer coefficients without offset.
+            coeff = Dict()
             solvable = []
             nonLinear = getCoefficients!(coeff, eq)
-           
+
             @static if VERSION < v"0.7.0-DEV.2005"
                 emptySet = []
             else
@@ -696,7 +696,7 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
                     push!(notLinearVariables, v)
                 end
             end
-            for inc in incidence 
+            for inc in incidence
                 if inc in keys(coeff) && coeff[inc] in [1, -1]
                     index = get(unknowns_indices, inc, 0)
                     if index == 0
@@ -705,23 +705,23 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
                             index = index + length(unknownsNames)
                         end
                     end
-                    if index != notFound 
+                    if index != notFound
                         push!(solvable, index)
-                    end                    
+                    end
                 end
             end
             push!(Gsolvable, sort(solvable))
         end
-    end    
+    end
 
-    names = createNames(unknownsNames, Avar)  
-    
+    names = createNames(unknownsNames, Avar)
+
     if removeSingularities
         (equations, G, Gsolvable, ESizes, nonStateVariables) = handleSingularities(coefficients, notLinearVariables, unknowns_indices, names, states, statesIndices, nonStateVariables, equations, orgEquIndex, Avar, G, Gsolvable, ESizes, logTiming)
     end
 
     # ------------------------------------------------
-  
+
     #=
     equationsInfix = []
     for e in equations
@@ -729,9 +729,9 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
     end
     #  equationsInfix = prettyPrint(equations)
     =#
-    equationsInfix = string.(prettyPrint.(equations)) 
+    equationsInfix = string.(prettyPrint.(equations))
     # equationsInfix = makeList(equationsInfix, 1:length(Bequ), Bequ, true)
-    
+
     # Set sizes of derivative variables
     VSizes = [VSizes; fill("", length(Avar) - length(VSizes))]
     for i in 1:length(Avar)
@@ -744,7 +744,7 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
 
     # ------------------------------------------------
 
-    if consistencyCheck    
+    if consistencyCheck
         loglnModia("\nPANTELIDES CONSISTENCY CHECK")
         printSymbolList("\nUnknowns", names, true, true, Avar)
 
@@ -764,21 +764,21 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
         logModia("\nCheck consistency of equations by matching extended equation set: ")
         EG::Array{Array{Int,1},1} = [G; buildExtendedSystem(Avar)]
         EESizes = copy(ESizes)
-        
+
         #= Double code
         for i in 1:length(Avar)
             a = Avar[i]
             if a > 0
                 # equation: v[i] = der(v[i]) => length(equ) = length(v[i])
-                push!(EESizes, VSizes[i])    
+                push!(EESizes, VSizes[i])
             end
         end
         =#
-        for i in length(G) + 1:length(EG)  
+        for i in length(G) + 1:length(EG)
             push!(EESizes, VSizes[EG[i][1]])
         end
 
-        if partial 
+        if partial
             println("Number of additional equations needed: ", length(VSizes) - length(ESizes))
             return nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing
         else
@@ -790,24 +790,24 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
             vActive = fill(true, length(Avar))
             vLengths = [prod(s) for s in VSizes]
             eLengths = [prod(s) for s in EESizes]
-        
+
             if log
                 @show VSizes
                 @show vLengths
                 @show eLengths
             end
-        
+
             if logTiming
                 print("Consistency check:     ")
                 @time assignEG = matchingArray(EG, vActive, vLengths, eLengths)
             else
                 assignEG = matchingArray(EG, vActive, vLengths, eLengths)
             end
-        
+
             loglnModia("---------------")
             loglnModia("assignEG=")
             for c in assignEG
-                loglnModia("  ", c)    
+                loglnModia("  ", c)
             end
         else
             if logTiming
@@ -817,19 +817,19 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
                 assignEG = matching(EG, length(Avar))
             end
         end
-        
+
         if log
             @show EG
             @show assignEG
         end
-    
+
         if false
             componentsEG = BLTArray(EG, assignEG, vLengths, eLengths)
             # @show componentsEG
         end
-    
+
         # checkAssign(assignEG, VSizes, VTypes, EESizes, ETypes, equationsEG, unknownsNames, Avar)
-    
+
         if !expandArrayIncidence && !all(assignEG .> 0) # Temporary disable check for expandArrayIncidence
             loglnModia("\nThe model is not consistent since all variables could not be assigned:")
             BequEG1 = fill(0, length(EG))
@@ -842,7 +842,7 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
         else
             loglnModia("Consistency check OK")
         end
-    
+
         if false # big skip
             if log
                 loglnModia("\nAssigned extended equations:")
@@ -859,7 +859,7 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
                 g = G[e]
                 @show g
                 int = intersect(unassigned, g )
-          
+
                 if int != []
                     @show int
                     @show e
@@ -880,43 +880,43 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
                 end
             end
             =#
-      
+
         end # big skip
-    end  
- 
+    end
+
     Bequ = fill(0, length(G))
-  
+
     # ------------------------------------------------
 
     # Add function arguments and unnest function.
-    function reduceDAEIndex() 
+    function reduceDAEIndex()
         loglnModia("\nINDEX REDUCTION")
         if expandArrayIncidence
             vLengths = [prod(s) for s in VSizes]
             eLengths = [prod(s) for s in ESizes]
-    
+
             if log
                 @show VSizes
                 @show vLengths
                 @show eLengths
             end
-    
+
             if logTiming
                 print("PantelidesArray:         ")
                 @time (assign, Avar, Bequ) = pantelidesArray!(G, length(Avar), Avar, vLengths, eLengths)
             else
                 (assign, Avar, Bequ) = pantelidesArray!(G, length(Avar), Avar, vLengths, eLengths)
             end
-    
+
             if log
                 @show Avar Bequ
             end
-    
+
             loglnModia("---------------")
             loglnModia("assign=")
-    
+
             for c in assign
-                loglnModia("  ", c)    
+                loglnModia("  ", c)
             end
 
         else
@@ -927,9 +927,9 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
                 (assign, Avar, Bequ) = pantelides!(G, length(Avar), Avar)
             end
         end
-  
+
         # checkSizes(VSizes, ESizes)   # VSizes, ESizes not up-to-date
-    
+
         if logIndexReduction
             # @show assign
             # @show Avar
@@ -938,19 +938,19 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
                 loglnModia("\nAssigned equations after index reduction:")
                 printAssignedEquations(equationsInfix, unknownsNames, 1:length(G), assign, Avar, Bequ)
             end
-        end  
+        end
 
         # Commented in order to be able to expandArrayIncidence
         # printUnassigned(equationsInfix, unknownsNames, assign, Avar, Bequ)
         loglnModia()
         ###  checkAssign(assign, VSizes, VTypes, ESizes, ETypes, equationsInfix, unknownsNames, Avar)
 
-        #=  
+        #=
         components = BLT(G, assign)
-  
+
         if log
             # @show components
-    
+
             loglnModia("\nSorted equations:")
             printSortedEquations(equationsInfix, unknownsNames, components, assign, Avar, Bequ)
         end
@@ -963,9 +963,9 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
             loglnModia("\nAugmented system.")
             @show AG
             @show assignAG
-            @show componentsAG  
-  
-            loglnModia("\nSorted augmented equations:")  
+            @show componentsAG
+
+            loglnModia("\nSorted augmented equations:")
             equationsAG = [equationsInfix; fill("der(...)", length(Bequ)-length(equations)); fill("full", length(Avar)-length(Bequ))]
             BAG = [Bequ; fill(0, length(Avar)-length(Bequ))] # Additional equations not differentiated
             printSortedEquations(equationsAG, unknownsNames, componentsAG, assignAG, Avar, BAG)
@@ -974,7 +974,7 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
                 loglnModia("The model is not consistent since all variables could not be assigned:")
                 printUnassigned(equationsAG, unknownsNames, assignAG, Avar, BAG)
                 loglnModia()
-            else 
+            else
                 loglnModia("Augmented system OK")
             end
         end
@@ -984,31 +984,31 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
     # ----------------------------
 
     assign = []
-    if indexReduction 
-        reduceDAEIndex() 
+    if indexReduction
+        reduceDAEIndex()
     end
-    
+
     loglnModia("\nSTATE SELECTION")
     IG = Array{Array{Int64,1},1}(G)
-    
+
     for i in 1:length(IG)-length(Gsolvable)
         push!(Gsolvable, [])  # This is conservative since highest derivative is not marked as solvable.
     end
 
-    if automaticStateSelection 
-		startValues = []
-		fixedFlags = []
-		for (name, var) in unknowns
-			push!(startValues, var.start)
-			push!(fixedFlags, var.fixed)
-		end
-		@show startValues
-		@show fixedFlags
+    if automaticStateSelection
+        startValues = []
+        fixedFlags = []
+        for (name, var) in unknowns
+            push!(startValues, var.start)
+            push!(fixedFlags, var.fixed)
+        end
+        @show startValues
+        @show fixedFlags
         components = Array{Array{Int64,1},1}(BLT(IG, assign))
         vNames = makeList(unknownsNames, 1:length(assign), Avar) # ::Vector{String}
         eqGraph = StateSelection.getSortedEquationGraph(IG, Gsolvable, components, assign, Avar, Bequ, vNames, withStabilization=false)
     end
-    
+
     if newStateSelection
         # Reduce graph
         newG = copy(IG)
@@ -1020,31 +1020,31 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
     if ! automaticStateSelection
         vActive[statesIndices] .= false
     else
-		stateIndices = eqGraph.Vx[ findall(x->x>0, eqGraph.Vx) ]   # Only use Vx indices that are > 0 (= no lambda variables)
-		@show names Avar stateIndices
-		@show Gsolvable
-		for i in 1:length(stateIndices)
-			j = stateIndices[i]
-			if j in Avar  # selected state is a derivative, but not a lambda variable and not an algebraic variable
-				# search for corresponding variable
-				alias = 0
-				for ie in 1:length(G)
-				    g = Gsolvable[ie]
-					if j in g && length(g) == 2 && sort(g) == sort(G[ie])
-						alias = if g[1] == j; g[2] else g[1] end
-						break;
-					end
-				end
-				@show alias i
-				stateIndices[i] = alias
-			end
-		end
-		
-		@show stateIndices
+        stateIndices = eqGraph.Vx[ findall(x->x>0, eqGraph.Vx) ]   # Only use Vx indices that are > 0 (= no lambda variables)
+        @show names Avar stateIndices
+        @show Gsolvable
+        for i in 1:length(stateIndices)
+            j = stateIndices[i]
+            if j in Avar  # selected state is a derivative, but not a lambda variable and not an algebraic variable
+                # search for corresponding variable
+                alias = 0
+                for ie in 1:length(G)
+                    g = Gsolvable[ie]
+                    if j in g && length(g) == 2 && sort(g) == sort(G[ie])
+                        alias = if g[1] == j; g[2] else g[1] end
+                        break;
+                    end
+                end
+                @show alias i
+                stateIndices[i] = alias
+            end
+        end
+
+        @show stateIndices
         vActive[stateIndices] .= false
         stateNames = [replace(replace(string(name), "(" => "_"), ")" => "") for name in names[stateIndices]]
         @show stateNames
-		@show realStates
+        @show realStates
         realStates = [GetField(This(), Symbol(name)) for name in stateNames]
         setRealStates(realStates)
     end
@@ -1066,15 +1066,15 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
         else
             assignIG = matchingArray(IG, vActive, vLengths, eLengths)
         end
-        
+
         if log
             @show assignIG
         end
         loglnModia("---------------")
         loglnModia("assignIG=")
-        
+
         for c in assignIG
-            loglnModia("  ", c)    
+            loglnModia("  ", c)
         end
         # assignIGTemp = [[e[1] for e in c][1] for c in assignIG]  # Not perfect within strong components
 
@@ -1093,9 +1093,9 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
     if !expandArrayIncidence
         (invAssign, unAssignedVariables) = invertAssign(assignIGTemp, length(Bequ))  ### Enabled again
     end
-    
+
     unassignedNames = [] # unknownsNames[unAssignedVariables]
-  
+
     # Check number of variables
     variableEquationDifference = length(IG) + length(realStates) - length(assignIG)
     if variableEquationDifference != 0
@@ -1113,29 +1113,29 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
         println("Number of equations: ", length(IG))
         println("Number of variables: ", length(assignIG))
         println("Number of continuous states: ", length(realStates))
-    
+
         if length(nonStateVariables) > 0
-            println("Number of non states: ", length(nonStateVariables))    
+            println("Number of non states: ", length(nonStateVariables))
         end
-    
+
         # printSymbolList("Unknowns: ", unknownsNames)
         # printSymbolList("Real states: ", realStates)
         # printSymbolList("Non states: ", nonStateVariables)
     end
-    
+
     if false # log
         @show IG
         @show assignIG
         @show invAssign
         @show Avar
         @show Bequ
-  
+
         loglnModia("\nAssigned equations after index reduction and state selection:")
         printAssignedEquations(equationsInfix, unknownsNames, 1:length(G), assignIGTemp, Avar, Bequ)
 
         printUnassigned(equationsInfix, unknownsNames, assignIGTemp, Avar, Bequ, vActive)
         loglnModia()
-    end  
+    end
 
     loglnModia("\nBLT TRANSFORMATION")
     if expandArrayIncidence
@@ -1143,13 +1143,13 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
         vNames = makeList(unknownsNames, 1:length(assignIG), Avar) # ::Vector{String}
         ii = 0
         for e in IG
-            loglnModia("  ", e) 
+            loglnModia("  ", e)
             ii += 1
             logModia(ii, " ")
             for v in e
                 logModia(vNames[v], " ")
             end
-            loglnModia()      
+            loglnModia()
         end
         # @show vNames[statesIndices]
 
@@ -1171,28 +1171,28 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
         end
         (invAssign, assignArray) = compactify(componentsIG, assignIG, vLengths, eLengths, vNames, equationsIG)
         # @show invAssign
-    
+
         loglnModia()
-        # @show componentsIG 
+        # @show componentsIG
         loglnModia("componentsIG=")
         for c in componentsIG
-            loglnModia("  ", c)    
+            loglnModia("  ", c)
         end
         loglnModia("Compacting")
         # All array variable elements belong to the same strongly connected components. So it's sufficient to pick out just the first element of the tuple. And remove duplicates.
         loglnModia()
         componentsIGorg = componentsIG
         # @show componentsIGorg
-        componentsIG = [unique([e[1] for e in c]) for c in componentsIG] 
+        componentsIG = [unique([e[1] for e in c]) for c in componentsIG]
         if log
             @show componentsIG
         end
         loglnModia("---------------")
         loglnModia("assignIG=")
         for c in assignIG
-            loglnModia("  ", c)    
+            loglnModia("  ", c)
         end
-        
+
         if log
             @show assignIG
         end
@@ -1215,10 +1215,10 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
         else
             componentsIG = BLT(IG, assignIG)
         end
-       
+
         if tearing
             loglnModia("\nTearing:")
-            
+
             equationsIG = [equationsInfix; fill("der(...)", length(Bequ) - length(equations))]
 
             if true # log
@@ -1237,23 +1237,23 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
 
                     td = TraverseDAG(IG, length(assignIG))
                     (eSolved, vSolved, eResidue, vTear) = tearEquations!(td, Gsolvable, es, vs)
-                    
+
                     for e in eSolved
                         push!(tornComponents, [e])
                     end
-                    
+
                     push!(tornComponents, eResidue)
-                      
+
                     for i in 1:length(eSolved)
                         assignIG[vSolved[i]] = eSolved[i]
                     end
                     for i in 1:length(eResidue)
                         # Mark by 0 that the equation can not be solved symbolically even if possible.
-                        assignIG[vTear[i]] = 0 # eResidue[i] 
+                        assignIG[vTear[i]] = 0 # eResidue[i]
                     end
 
-#                   (invAssign, unAssignedVariables) = invertAssign(assignIG, length(Bequ)) 
-                    
+#                   (invAssign, unAssignedVariables) = invertAssign(assignIG, length(Bequ))
+
                     if length(c) > length(eResidue)
                         loglnModia("Reduced system of equation size from $(length(c)) to $(length(eResidue))")
                     else
@@ -1264,10 +1264,10 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
             componentsIG = tornComponents
         end
     end
-  
+
     if log
-        @show componentsIG    
-    end  
+        @show componentsIG
+    end
 
     if newStateSelection
         (sortedEquations, equation_code) = performNewStateselection(unknownsNames, deriv, equations, equationsInfix, newG, assignIG, newAssign, Avar, Bequ, expandArrayIncidence)
@@ -1275,84 +1275,84 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
         sortedEquations = nothing
         equation_code = nothing
     end
-  
+
     if newStateSelection || useKinsol && false ## Disable simulation for 0.7
         generateCode(newStateSelection, useKinsol, params, realStates, unknownsNames, deriv, equations, componentsIG, assignIG, Avar, Bequ, VSizes, ESizes, invAssign, sortedEquations, equation_code, unknowns)
-    
-        return nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing
-    end  
 
-    # ---  
+        return nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing
+    end
+
+    # ---
     incidenceMatrix = spzeros(Bool, length(IG), length(assignIG))
-  
+
     for i in 1:length(IG)
         for j in 1:length(IG[i])
             incidenceMatrix[i, IG[i][j]] = true
         end
     end
-  
+
     if false # PrintFinalIncidenceMatrix
         intIncidenceMatrix = [if incidenceMatrix[i,j]; 1 else 0 end for i in 1:size(incidenceMatrix, 1), j in 1:size(incidenceMatrix, 2)]
         @show intIncidenceMatrix
     end
-  
+
     DAEvariables = []
     for i in 1:n
         if !vActive[i] || i > length(unknownsNames)  # state or derivative
             push!(DAEvariables, i)
         end
     end
-  
+
     # @show DAEvariables
-  
+
     derVar = length(unknownsNames) + 1:n
     # @show derVar
     derEqu = assignIG[derVar]
     # @show derEqu
-  
+
     if useIncidenceMatrix
         incidenceMatrix = spzeros(Bool, length(IG), length(assignIG))
-    
+
         for equnr in derEqu
             collectIncidence!(equnr, equnr, incidenceMatrix, IG, DAEvariables, assignIG, 0)
         end
         # incidenceMatrix = incidenceMatrix[derEqu, DAEvariables]
         # @show incidenceMatrix
-    
+
         n2 = div(length(DAEvariables), 2)
         # Treat state and derivative as same incidence:
         incidenceMatrix = incidenceMatrix[derEqu, DAEvariables[1:n2]] .| incidenceMatrix[derEqu, DAEvariables[n2 + 1:length(DAEvariables)]]
-    
+
         if false # PrintFinalIncidenceMatrix
             intIncidenceMatrix = [if incidenceMatrix[i,j]; 1 else 0 end for i in 1:size(incidenceMatrix, 1), j in 1:size(incidenceMatrix, 2)]
             @show intIncidenceMatrix
         end
 
         intIncidenceMatrix = nothing
-    end  
-  
+    end
+
     equationsIG = [equationsInfix; fill("der(...)", length(Bequ) - length(equations))]
-  
+
     if true # log
         loglnModia("\nSorted state equations:")
         printSortedEquations(equationsIG, unknownsNames, componentsIG, assignIG, Avar, Bequ)
         loglnModia()
     end
-  
+
     variables = [unknownsNames; deriv]
     # solveSortedEquations(equationsIG, [unknownsNames; deriv], componentsIG, assignIG, Avar, Bequ)
-  
+
     if false # ! all([assignIG[i] > 0 || ! vActive[i] for i in 1:length(vActive)]) # Temporary disable check for expandArrayIncidence
         loglnModia("\nThe model is not consistent since all variables could not be assigned:")
-    
+
         @show assignIG
         @show Avar
         @show Bequ
         error("Translation of model aborted")
     end
-  
+
     loglnModia("End of structural processing.")
-  
+
     return equations, equationsIG, variables, assignIG, componentsIG, Avar, Bequ, states, deriv, unassignedNames, incidenceMatrix, VSizes, VTypes, ESizes, ETypes
 end
 
@@ -1364,7 +1364,7 @@ Add function arguments
 """
 function  performNewStateselection(unknownsNames, deriv, equations, equationsInfix, newG, assignIG, newAssign, Avar, Bequ, expandArrayIncidence)
     loglnModia("\nNEW STATE SELECTION")
-    
+
     # Remove non-leading variables from IG
     if log
         @show IG Avar
@@ -1375,17 +1375,17 @@ function  performNewStateselection(unknownsNames, deriv, equations, equationsInf
     # IG = [[j for j in G[i] if Bequ[i] != 0 || orgBIndex[i] != 0 && !(j in IG[orgBIndex[i]])] for i in 1:length(IG)]
     # Gsolvable = fill([], length(IG))  # Temporary
     # Gsolvable = newG
- 
-    Gsolvable = [] 
+
+    Gsolvable = []
     vNames = makeList(unknownsNames, 1:length(assignIG), Avar) # ::Vector{String}
     @show vNames
-    
+
     for eq in equations
-        coeff = Dict() 
+        coeff = Dict()
         nonLinear = false
         nonLinear = findCoefficients!(coeff, nonLinear, eq)
         solvable = []
-    
+
         for (var, value) in coeff
             if value in [1, -1]
                 ind = findfirst(isequal(string(var)), vNames)
@@ -1395,38 +1395,38 @@ function  performNewStateselection(unknownsNames, deriv, equations, equationsInf
             end
         end
         push!(Gsolvable, sort(solvable))
-    end   
-    
+    end
+
     for i in length(Gsolvable) + 1:length(newG)
         solvable = [Avar[v] for v in newG[i] if Avar[v] > 0]
         push!(Gsolvable, solvable)
-    end    
-    
+    end
+
     if log
         @show length(newAssign) length(componentsIG)
         @show length(newG) newG length(Avar) length(Bequ)
     end
-    
+
     if expandArrayIncidence
         if log
             @show IG
             @show newAssign vLengths eLengths
         end
-    
+
         print("BLTArray:                ")
         @time bltA = BLTArray(newG, newAssign, vLengths, eLengths)
         @show bltA
-        blt = [unique([e[1] for e in c]) for c in bltA] 
+        blt = [unique([e[1] for e in c]) for c in bltA]
         @show blt
-    else    
+    else
         print("BLT     :                ")
         @time blt = BLT(newG, newAssign)
     end
-    
+
     if log
         @show componentsIG
     end
-    
+
     blt = [Array{Int64,1}(c) for c in blt]
 
     printSymbolList("\nvNames", vNames, true, true, Avar)
@@ -1435,7 +1435,7 @@ function  performNewStateselection(unknownsNames, deriv, equations, equationsInf
     if log
         @show newG Gsolvable blt newAssign Avar Bequ
     end
-    
+
     newAssign = [[e[1] for e in c][1] for c in newAssign]  # Not perfect within strong components
 
     if log
@@ -1444,48 +1444,48 @@ function  performNewStateselection(unknownsNames, deriv, equations, equationsInf
         @show newG Gsolvable blt newAssign Avar Bequ vNames
         println("sortedEquations = getSortedEquationGraph(newG, Gsolvable, blt, newAssign, Avar, Bequ, vNames)")
     end
-    
+
     sortedEquations = getSortedEquationGraph(newG, Gsolvable, blt, newAssign, Avar, Bequ, vNames)
     loglnModia()
-    
+
     if log
         @show sortedEquations.isorted
         @show sortedEquations.irbeg
-        @show sortedEquations.ESorted 
+        @show sortedEquations.ESorted
         @show sortedEquations.ESolved
-        @show sortedEquations.rcat    
-        @show sortedEquations.Vx 
+        @show sortedEquations.rcat
+        @show sortedEquations.Vx
         @show sortedEquations.VxRev
         @show sortedEquations.Vderx
         @show sortedEquations.VderxRev
         @show sortedEquations.nc
         @show sortedEquations.Er
         @show sortedEquations.ider0n2
-        @show sortedEquations.ider1n1   
+        @show sortedEquations.ider1n1
     end
-    
-    printSortedEquationGraph(sortedEquations)      
-    
+
+    printSortedEquationGraph(sortedEquations)
+
     loglnModia("\nSorted variables")
     for i in sortedEquations.ESolved
         if i > 0
-            loglnModia(i, ": ", vNames[i])   
+            loglnModia(i, ": ", vNames[i])
         else
-            loglnModia("  : r[", string(-i), "]")       
+            loglnModia("  : r[", string(-i), "]")
         end
     end
-    
-    loglnModia("\nSorted equations")    
+
+    loglnModia("\nSorted equations")
     printAssignedEquations(equationsInfix, unknownsNames, sortedEquations.ESorted, fill(0, length(vNames)), Avar, Bequ)
-    
+
     variables = [unknownsNames; deriv]
     equation_code = newDifferentiateEquations(equations, variables, Avar, Bequ, sortedEquations.ESorted, sortedEquations.ESolved)
     return sortedEquations, equation_code
 end
-    
+
 # -----------------------------------------------------------------------------
 
-""" 
+"""
 Experimental code for code generation with Kinsol. Should be merged.
 """
 function generateCode(newStateSelection, useKinsol, params, realStates, unknownsNames, deriv, equations, componentsIG, assignIG, Avar, Bequ, VSizes, ESizes, invAssign, sortedEquations, equation_code, unknowns)
@@ -1502,17 +1502,17 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
     info = ModiaMath.NonlinearEquationsInfo(\"\", length(y), f!)
     ModiaMath.solveNonlinearEquations!(info, y)
     return y
-  end" * "\n\n"      
+  end" * "\n\n"
 
     if logFDAE
         func *= "  @show _x _der_x\n"
     end
-    
+
     func *= "  # Set parameters\n"
-    
+
     for (p, v) in params
         pName = replace(string(p), ".", "_")
-        func *= "  " * pName * " = " * string(v) * "\n"  
+        func *= "  " * pName * " = " * string(v) * "\n"
         if logFDAE
             func *= "  " * "@show $pName" * "\n"
         end
@@ -1529,7 +1529,7 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
                 func *= "  " * "@show $xName" * "\n"
             end
         end
-    
+
         for i in 1:length(sortedEquations.Vderx)
             if sortedEquations.Vderx[i] > 0
                 der_xName = replace(string(vNames[sortedEquations.Vderx[i]]), ".", "_")
@@ -1539,7 +1539,7 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
                 end
             end
         end
-    
+
         for i in eachindex(sortedEquations.ider0n2)
             iderx = sortedEquations.VxRev[ sortedEquations.ider0n2[i] ]
             ix    = sortedEquations.VxRev[ sortedEquations.ider1n1[i] ]
@@ -1550,7 +1550,7 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
         for (solution, solved) in equation_code
             pp = prettyPrint(solution)
             pp = replace(string(pp), "der(", "(der_")
-            pp = replace(string(pp), "der_der_", "der2_")      
+            pp = replace(string(pp), "der_der_", "der2_")
             if logFDAE
                 func *= "  " * "println(\"$pp\")" * "\n"
             end
@@ -1563,7 +1563,7 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
             printSortedEquations(equations, unknownsNames, componentsIG, assignIG, Avar, Bequ)
             loglnModia()
         end
-      
+
         func *= "  # Copy state vector and derivative vector to each state and derivative\n"
         for i in 1:length(realStates)
             xName = replace(string(realStates[i]), ".", "_")
@@ -1571,7 +1571,7 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
             derName = "der_" * xName
             func *= "  $(xName) = _x[$i]\n"
             func *= "  $(derName) = _der_x[$i]\n"
-        
+
             if logFDAE
                 func *= "  " * "@show $xName" * "\n"
                 func *= "  " * "@show $derName" * "\n"
@@ -1604,7 +1604,7 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
         end
         func *= ") = _x" * "\n"
         =#
- 
+
         # Traverse all BLT blocks
         func *= "\n"
         func *= "  # Equations\n"
@@ -1612,12 +1612,12 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
         for blockIndex in 1:length(solvedComponents)
             c = solvedComponents[blockIndex]
             residualIndex = 0
-            if length(c) > 1 
+            if length(c) > 1
                 func *= "\n"
                 func *= "  # Code for solving systems of equations\n"
                 # Generate code for solving systems of equations
                 # m = length(c)
-                # Calculate sizes of y vecor          
+                # Calculate sizes of y vecor
                 m = 0
                 for j in 1:length(componentsIG[blockIndex])
                     equIndex = componentsIG[blockIndex][j]
@@ -1631,7 +1631,7 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
                         println()
                     end
                 end
-          
+
                 func *= "  _y = solve(ones($m), "
                 func *= " function (info, _y, _r)" * "\n"
                 if logFDAE
@@ -1639,7 +1639,7 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
                 end
                 # (assignedVar, unAssigned) = invertAssign(assignIG)
                 assignedVar = invAssign
-          
+
                 vIndex = 0
                 func *= "    # Copy unknowns vector to each unknown\n"
                 for j in 1:length(componentsIG[blockIndex])
@@ -1652,7 +1652,7 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
                     (orgIndexVar, derOrderVar) = invertDer(Avar)
                     if varIndex == 0
                         @show blockIndex
-                        @show componentsIGorg[blockIndex] componentsIG[blockIndex] 
+                        @show componentsIGorg[blockIndex] componentsIG[blockIndex]
                         @show j
                         @show equIndex
                         @show assignedVar
@@ -1672,10 +1672,10 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
 
                         vName = vNames[varIndex]
                         vName = replace(string(vName), ".", "_")
-  
+
                         if VSizes[varIndex] == ()
                             vIndex += 1
-                            func *= "    $(vName) = _y[$vIndex]" * "\n"            
+                            func *= "    $(vName) = _y[$vIndex]" * "\n"
                         else
                             i1 = vIndex + 1
                             s = prod(VSizes[varIndex])
@@ -1687,13 +1687,13 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
 
                         if logFDAE
                             func *= "    " * "@show $vName" * "\n"
-                        end              
+                        end
                     end
                 end
                 func *= "\n"
                 func *= "    # Create residuals for system of equations\n"
             end
-        
+
             # for (e, solved) in c
             for j in 1:length(componentsIG[blockIndex])
                 (e, solved) = c[j]
@@ -1703,15 +1703,15 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
                 if !solved && length(c) > 1
                     if ESizes[equIndex] == ()
                         residualIndex += 1
-                        e = :(_r[$residualIndex] = $(e.args[1]) - $(e.args[2]))        
+                        e = :(_r[$residualIndex] = $(e.args[1]) - $(e.args[2]))
                     else
                         i1 = residualIndex + 1
                         s = prod(ESizes[equIndex])
                         i2 = residualIndex + s
-                        e = :(_r[$i1:$i2] = reshape($(e.args[1]) - $(e.args[2]), ($s,)))        
+                        e = :(_r[$i1:$i2] = reshape($(e.args[1]) - $(e.args[2]), ($s,)))
                         residualIndex += s
                     end
-                elseif !solved 
+                elseif !solved
                     println("useKinsol")
                     println(e)
                     # globalResidualIndex += 1
@@ -1719,8 +1719,8 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
                 end
                 pp = prettyPrint(e)
                 pp = replace(string(pp), "der(", "(der_")
-                pp = replace(string(pp), "der_der_", "der2_")      
-                
+                pp = replace(string(pp), "der_der_", "der2_")
+
                 if logFDAE
                     if length(c) > 1
                         func *= "  "
@@ -1742,7 +1742,7 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
                     func *= "  @show _y" * "\n"
                 end
                 func *= "\n"
-          
+
                 func *= "  # Copy unknowns vector to each unknown\n"
                 vIndex = 0
                 for j in 1:length(componentsIG[blockIndex])
@@ -1763,10 +1763,10 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
 
                         vName = vNames[varIndex]
                         vName = replace(string(vName), ".", "_")
-    
+
                         if VSizes[varIndex] == ()
                             vIndex += 1
-                            func *= "    $(vName) = _y[$vIndex]" * "\n"            
+                            func *= "    $(vName) = _y[$vIndex]" * "\n"
                         else
                             i1 = vIndex + 1
                             s = prod(VSizes[varIndex])
@@ -1778,7 +1778,7 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
 
                         if logFDAE
                             func *= "    " * "@show $vName" * "\n"
-                        end              
+                        end
                     end
                 end
                 func *= "\n"
@@ -1787,7 +1787,7 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
 
         func *= "\n"
         func *= "  # Create residual vector for derivatives\n"
-      
+
         for i in 1:length(realStates)
             xName = replace(string(realStates[i]), ".", "_")
             xName = replace(xName, "this_", "")
@@ -1808,25 +1808,25 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
     end
     func *= "end\n"
     func *= "\nend\n"
-    
+
     loglnModia(func)
-    
+
     # Allow editing of FDAE
     if false
         open("FDAE.jl", "w") do f
         write(f, func)
       end
     end
-    
+
     if false
         open("FDAE.jl") do f
         func = readstring(f)
       end
     end
-    
+
     FUNC = parse(func)
     fdae = eval(FUNC)
-    
+
     if newStateSelection
         loglnModia("Initial conditions")
         x0 = fill(0.0, length(sortedEquations.Vx))
@@ -1841,15 +1841,15 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
                     println("Not found: $(string(name)), start=$(var.start)")
                 end
             end
-        end      
-      
+        end
+
         @show x0
         der_x0 = zeros(length(sortedEquations.Vderx))
         r = zeros(length(sortedEquations.Er))
         @show r
         nc = sortedEquations.nc
     end
-    
+
     # Temporary code for testing:
     #    m = ModiaSimulationModel(model_name_of(instance), FDAE, x0, der_x0, jac;
     #                             maxSparsity=maxSparsity, nz=initial_m.nz_preInitial,
@@ -1859,20 +1859,20 @@ function generateCode(newStateSelection, useKinsol, params, realStates, unknowns
 
     m = ModiaSimulationModel("test", ModuleFDAE.FDAE, x0) #, der_x0, nothing)
     #                        nc=nc)
-    #=  
+    #=
     println("Call FDAE once")
     w = []
     Base.invokelatest(ModuleFDAE.FDAE, m, 0, x0, der_x0, r, w)
     println("FDAE called")
     @show r
     @show x0
-    =#    
-    
+    =#
+
     if length(x0) > 0
         println("\nSimulate")
         t = linspace(0.0, 50, 1000)
         result = ModiaMath.ModiaToModiaMath.simulate(m, t; log=false, tolRel=1E-5)
-        
+
 #= Temporarily removed due to problem with PyPlot
         # Plot results
         t = result["time"]

--- a/src/symbolic/DAEquations/BasicStructuralTransform.jl
+++ b/src/symbolic/DAEquations/BasicStructuralTransform.jl
@@ -1004,7 +1004,6 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
 		end
 		@show startValues
 		@show fixedFlags
-	    println(... 2)
         components = Array{Array{Int64,1},1}(BLT(IG, assign))
         vNames = makeList(unknownsNames, 1:length(assign), Avar) # ::Vector{String}
         eqGraph = StateSelection.getSortedEquationGraph(IG, Gsolvable, components, assign, Avar, Bequ, vNames, withStabilization=false)


### PR DESCRIPTION
The commit 4540fc2  removes the line 1007 call to `println` which has a syntax error. The other commit is a whitespace autoformat.