### PR TITLE
Close log file prior to each error(...)

### DIFF
--- a/src/language/Instantiation.jl
+++ b/src/language/Instantiation.jl
@@ -251,7 +251,7 @@ end
 "Check that a start value (possibly default) exists for the var, or give an error."
 function check_start(var::Variable, name)
     if (var.start === nothing) && (var.typ !== Nothing) && !applicable(zero, var.typ)
-        error("Variable ", name, " has no start value and no default exists for type ", var.typ)
+        ModiaLogging.closeLogModiaAndError("Variable ", name, " has no start value and no default exists for type ", var.typ)
     end
 end
 
@@ -887,14 +887,14 @@ initializer_getfield(x, name::Symbol) = getfield(x, name)
 function initializer_getfield(instance::Instance, name::Symbol)
     if !haskey(instance.variables, name)
         ModiaLogging.increaseLogCategory(:NoFieldDefined)
-        error("No field ", name, " defined in model ", instance.model_name, " (yet)")
+        ModiaLogging.closeLogModiaAndError("No field ", name, " defined in model ", instance.model_name, " (yet)")
     end
     instance.variables[name]
 end
 
 "Give an error message that no initializer has been defined for a varible."
 function no_initializer(inst::Instance, name::Symbol)
-    error("No initializer given for variable $(model_name_of(inst)).$name")
+    ModiaLogging.closeLogModiaAndError("No initializer given for variable $(model_name_of(inst)).$name")
 end
 
 # -------------------------------- instantiate --------------------------------
@@ -906,7 +906,7 @@ as_field_value(insts::Vector{Instantiations}, time::Float64) = Instance[instanti
 
 function add_variable!(instance::Instance, name::Symbol, value)
     if haskey(instance.variables, name)
-        # error("Multiple definitions of $(name) in $(model_name_of(instance))")
+        # ModiaLogging.closeLogModiaAndError("Multiple definitions of $(name) in $(model_name_of(instance))")
         println("Multiple definitions of $(name) in $(model_name_of(instance))")
     end
     instance.variables[name] = value
@@ -945,7 +945,7 @@ function instantiate_equation!(instance::Instance, eq)
     println("Conditional equation:")
     println(prettyPrint(eq)) 
     if length(eq.args) > 3 
-        error("elseif is presently not handled.")
+        ModiaLogging.closeLogModiaAndError("elseif is presently not handled.")
     end
     cond = eq.args[1]
     if typeof(cond) == GetField # only handle name that resolves in the model for now
@@ -961,12 +961,12 @@ function instantiate_equation!(instance::Instance, eq)
               cond_value = cond_value.value
             end
         else
-            error("Too complex expression: $cond")
+            ModiaLogging.closeLogModiaAndError("Too complex expression: $cond")
         end
         if op == !
             cond_value = ! cond_value
         else
-            error("Not handled operator.")
+            ModiaLogging.closeLogModiaAndError("Not handled operator.")
         end
     end
     println("condition = ", cond_value)
@@ -975,7 +975,7 @@ function instantiate_equation!(instance::Instance, eq)
     if eq_index <= length(eq.args)
       branch_eq = eq.args[eq_index]
       if ! (branch_eq.head in [:(=), :block])
-          error("At most one equation is currently allowed in conditional equation.")
+          ModiaLogging.closeLogModiaAndError("At most one equation is currently allowed in conditional equation.")
       end
       
       if branch_eq.head == :(=) 
@@ -1108,7 +1108,7 @@ get_this_fieldname(g::GetField) = (@assert g.base === This(); g.name)
 get_connection_sign(ex::This) = false
 
 function get_connection_sign(ex::GetField)
-    if !isa(ex.base, This); error("Can only connect current model and submodels"); end
+    if !isa(ex.base, This); ModiaLogging.closeLogModiaAndError("Can only connect current model and submodels") end
     true
 end
 
@@ -1125,7 +1125,7 @@ function add_connection!(flat::Flat, prefix::AbstractString, instance::Instance,
     if eq.a.name in keys(vars_of(inst))
         atype = get_connector_type(lookup(instance, eq.a))
     else
-        error("Connector $(eq.a.name) not found in: $eq in model $(instance.model_name)")
+        ModiaLogging.closeLogModiaAndError("Connector $(eq.a.name) not found in: $eq in model $(instance.model_name)")
     end
 
     inst = lookup(instance, eq.b.base)
@@ -1135,7 +1135,7 @@ function add_connection!(flat::Flat, prefix::AbstractString, instance::Instance,
     if eq.b.name in keys(vars_of(inst))
         btype = get_connector_type(lookup(instance, eq.b))
     else
-        error("Connector $(eq.b.name) not found in: $eq in model $(instance.model_name)")
+        ModiaLogging.closeLogModiaAndError("Connector $(eq.b.name) not found in: $eq in model $(instance.model_name)")
     end
 
     if atype != btype

--- a/src/language/ModiaLogging.jl
+++ b/src/language/ModiaLogging.jl
@@ -6,7 +6,7 @@ global logName = "Modia_log"
 
 # ----------------------------------------------
 
-export openLogModia, logModia, loglnModia, closeLogModia, logFileModia, setDefaultLogName, resetTestStatus, setTestStatus, increaseLogCategory, printTestStatus
+export openLogModia, logModia, loglnModia, closeLogModia, closeLogModiaAndError, logFileModia, setDefaultLogName, resetTestStatus, setTestStatus, increaseLogCategory, printTestStatus
 
 global logTranslation = logTranslationDefault
 
@@ -63,6 +63,11 @@ end
 logModia(args...) = if logTranslation; print(logFileModia, args...) else end
 loglnModia(args...) = if logTranslation; println(logFileModia, args...) else end
 closeLogModia() = if logOnFile && logTranslation; close(logFileModia) else end
+
+function closeLogModiaAndError(args...)
+	closeLogModia()
+	error(args...)
+end
 
 global nOK = 0
 global nNOTOK = 0

--- a/src/language/Unitful_U_str.jl
+++ b/src/language/Unitful_U_str.jl
@@ -31,7 +31,7 @@ const allowed_funcs = [:*, :/, :^, :sqrt, :√, :+, :-, ://]
 function replace_value(ex::Expr)
     if ex.head == :call
         ex.args[1] in allowed_funcs ||
-            error("""$(ex.args[1]) is not a valid function call when parsing a unit.
+            ModiaLogging.closeLogModiaAndError("""$(ex.args[1]) is not a valid function call when parsing a unit.
              Only the following functions are allowed: $allowed_funcs""")
         for i=2:length(ex.args)
             if typeof(ex.args[i])==Symbol || typeof(ex.args[i])==Expr
@@ -44,12 +44,12 @@ function replace_value(ex::Expr)
             if typeof(ex.args[i])==Symbol
                 ex.args[i]=replace_value(ex.args[i])
             else
-                error("only use symbols inside the tuple.")
+                ModiaLogging.closeLogModiaAndError("only use symbols inside the tuple.")
             end
         end
         return ex
     else
-        error("Expr head $(ex.head) must equal :call or :tuple")
+        ModiaLogging.closeLogModiaAndError("Expr head $(ex.head) must equal :call or :tuple")
     end
 end
 

--- a/src/symbolic/BLTandPantelides/BLTandPantelides.jl
+++ b/src/symbolic/BLTandPantelides/BLTandPantelides.jl
@@ -151,7 +151,7 @@ function checkAssign(assign, VSizes, VTypes, ESizes, ETypes, equationsInfix, var
     if assignmentOK
         println("Assignment is OK")
     else
-        # error("Assignment not OK")
+        # ModiaLogging.closeLogModiaAndError("Assignment not OK")
   end
 end
 

--- a/src/symbolic/DAEquations/BasicStructuralTransform.jl
+++ b/src/symbolic/DAEquations/BasicStructuralTransform.jl
@@ -636,7 +636,7 @@ end
 const tSizes = Array{Tuple{Int64,Vararg{Int64,N} where N},1}
 
 function analyzeStructurally(equations, params, unknowns_indices, deriv, unknownsNames, Avar, statesIndices, states, nonStateVariables, n, realStates, findIncidence!, VSizes, VTypes, ESizes, ETypes, unknowns, partial)
-  # Build incidence structure as bipartite graph.
+    # Build incidence structure as bipartite graph.
     neq = 0
     G = [] # Array{Any}(undef, 0)
     Gsolvable = []
@@ -837,8 +837,8 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
 
             loglnModia("\nAssigned equations:")
             printAssignedEquations(equationsEG, unknownsNames, 1:length(EG), assignEG, Avar, fill(0, length(EG)))
-            loglnModia()
-            error("Translation of model aborted since model not consistent. See log file.")
+            loglnModia("")
+            ModiaLogging.closeLogModiaAndError("Translation of model aborted since model not consistent. See log file.")
         else
             loglnModia("Consistency check OK")
         end
@@ -1099,7 +1099,8 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
     # Check number of variables
     variableEquationDifference = length(IG) + length(realStates) - length(assignIG)
     if variableEquationDifference != 0
-       error("\nThe number of equations and the number of unknowns/states does not match.",
+       ModiaLogging.closeLogModiaAndError(
+             "\nThe number of equations and the number of unknowns/states does not match.",
              "\n   Number of equations: ", length(IG),
              "\n   Number of variables: ", length(assignIG),
              "\n   Number of continuous states: ", length(realStates),
@@ -1348,7 +1349,7 @@ function analyzeStructurally(equations, params, unknowns_indices, deriv, unknown
         @show assignIG
         @show Avar
         @show Bequ
-        error("Translation of model aborted")
+        ModiaLogging.closeLogModiaAndError("Translation of model aborted")
     end
 
     loglnModia("End of structural processing.")

--- a/src/symbolic/DAEquations/SymbolicTransform.jl
+++ b/src/symbolic/DAEquations/SymbolicTransform.jl
@@ -318,7 +318,7 @@ function solve(eq::Expr, x)
                 return eq, true
                 dump(ex)
                 dump(x)
-                error("Should not happen")
+                closeLogModiaAndError("Should not happen")
             end
 
         elseif op in [*, :*, +, :+, -, :-, /, :/]   # ^, :^]
@@ -401,7 +401,7 @@ function solve(eq::Expr, x)
         end
 
         if logSolve println("  Never solved: ", prettyPrint(eq)) end
-        error("Should not happen")
+        closeLogModiaAndError("Should not happen")
         return eq, false
     else
         # println("Should not happen:")
@@ -409,11 +409,11 @@ function solve(eq::Expr, x)
         # dump(eq.args[2])
         # dump(x)
         return eq, false
-        error("Should not happen")  # Check up!!!
+        closeLogModiaAndError("Should not happen")  # Check up!!!
     end
   
     if logSolve println("  Not solved: ", prettyPrint(eq)) end
-    error("Should not happen")
+    closeLogModiaAndError("Should not happen")
     return eq, false
 end
 
@@ -816,7 +816,7 @@ function differentiate(e)
                     if mod == ""
                         println("Derivative function ", string(f_der), " not found.")
                     elseif ! (f_der in names(getfield(Main, Symbol(mod))))
-                        error("Derivative function ", string(f_der), " not found.")
+                        closeLogModiaAndError("Derivative function ", string(f_der), " not found.")
                     else
                         f_der = getfield(getfield(Main, Symbol(mod)), f_der)
                     end

--- a/src/symbolic/StateSelection.jl
+++ b/src/symbolic/StateSelection.jl
@@ -29,6 +29,8 @@ dummy derivative method). Details are described in the paper:
 """
 module StateSelection
 
+import ..ModiaLogging
+
 # export SortedEquationGraph
 # export getSortedEquationGraph!
 export getSortedEquationGraph
@@ -114,7 +116,7 @@ function getConstraintSets(eBLT::Vector{Int}, Eassign::Vector{Int}, Arev::Vector
       
         end
         if length(veq) == 0;
-            error("Error should not occur: eBLT equations and vBLT variables have different differentiation orders");
+            ModiaLogging.closeLogModiaAndError("Error should not occur: eBLT equations and vBLT variables have different differentiation orders");
         end
       
         @static if VERSION < v"0.7.0-DEV.2005"
@@ -402,7 +404,7 @@ If yes, mark this in eq.EAlgebraic and eq.VAlgebraic
 """
 function determineAlgebraicProperty!(eq::SortedEquationGraph, ec::Vector{Int})
     if length(ec) == 0
-        error("... Internal error in checkAlgebraicProperty!(..) in StateSelection.jl: length(ec) = 0")
+        ModiaLogging.closeLogModiaAndError("... Internal error in checkAlgebraicProperty!(..) in StateSelection.jl: length(ec) = 0")
     end
    
     for eci in ec                  # for all equations in ec
@@ -432,7 +434,7 @@ function deduceHigher(vLower::Vector{Int}, A)
     for i in eachindex(vLower)
         derv = A[ vLower[i] ]
         if derv == 0
-            error("... Internal error in StateSelection.jl: vLower/eLower = ", vLower[i], " has no derivative.")
+            ModiaLogging.closeLogModiaAndError("... Internal error in StateSelection.jl: vLower/eLower = ", vLower[i], " has no derivative.")
         end
         v[i] = derv
     end
@@ -501,12 +503,14 @@ function getSortedEquationGraph(G, Gsolvable, BLT, assign, A, B, VNames; withSta
             end
 
             if length(lambdaVariables) > 0
-                error("\n... Automatic state selection is not possible, because the code generator does not\n",
+                ModiaLogging.closeLogModiaAndError(
+                      "\n... Automatic state selection is not possible, because the code generator does not\n",
                       "    yet support DAE stabilization of higher index systems.\n",
                       "    Number of lambda variables: ", length(lambdaVariables), ", number of mue variables: ", eq.nmue, "\n",
                       "    The following (lambda) variables are the reason: ", lambdaVariables, ".")
             elseif eq.nmue > 0
-                error("\n... Automatic state selection is not possible, because the code generator does not\n",
+                ModiaLogging.closeLogModiaAndError(
+                      "\n... Automatic state selection is not possible, because the code generator does not\n",
                       "    yet support the generation of stabilizing equations.\n",
                       "    Number of lambda variables: ", length(lambdaVariables), ", number of mue variables: ", eq.nmue, "\n",
                       "    The following (state) variables are the reason: ", constraintVariables, ".")      
@@ -522,7 +526,8 @@ function getSortedEquationGraph(G, Gsolvable, BLT, assign, A, B, VNames; withSta
                 vc = eq.Vx[ eq.VxRev[ i ] ]
                 push!(constraintVariables, eq.VNames[ vc ])
             end
-            error("\n... Automatic state selection is not possible, because the code generator does not\n",
+            ModiaLogging.closeLogModiaAndError(
+                  "\n... Automatic state selection is not possible, because the code generator does not\n",
                   "    yet support the generation of stabilizing equations.\n",
                   "    Number of mue variables: ", eq.nmue, "\n",
                   "    The following (state) variables are the reason: ", constraintVariables, ".")      
@@ -563,8 +568,9 @@ Output arguments in sortedEquationGraph:
 """
 function getSortedEquationGraph!(eq::SortedEquationGraph, Gsolvable)
     if !eq.first
-        error("... getSortedEquationGraph(..) of StateSelection.jl is called twice with the same sortedEquationGraph object.\n",
-            "    This is not possible. You need to instanciate SortedEquationGraph once for every getSortedEquationGraph(..) call.")
+        ModiaLogging.closeLogModiaAndError(
+            "... getSortedEquationGraph(..) of StateSelection.jl is called twice with the same sortedEquationGraph object.\n",
+            "    This is not possible. You need to instantiate SortedEquationGraph once for every getSortedEquationGraph(..) call.")
     else
         eq.first = false
     end
@@ -833,10 +839,10 @@ function printSortedEquationGraph(eq::SortedEquationGraph; equations::Bool=true)
    
    # Raise error, if dimensions do not agree
     if length(eq.Vx) + length(eq.Vmue) != length(eq.Er)
-        error("... length(_x) != length(_r)")
+        ModiaLogging.closeLogModiaAndError("... length(_x) != length(_r)")
     end
     if eq.nc > length(eq.Er)
-        error("... nc > length(Er)")
+        ModiaLogging.closeLogModiaAndError("... nc > length(Er)")
     end
    
 end

--- a/src/symbolic/StructuralTransform.jl
+++ b/src/symbolic/StructuralTransform.jl
@@ -193,7 +193,7 @@ function findAliases!(nonAliasEquations, aliases, eq::Expr, unknowns, defined)
                     @show e1.name, unknowns[e1.name].state
                 else 
                     println("Circular aliases between: $e1 and $e2")
-#                    error("Aborting")
+#                    ModiaLogging.closeLogModiaAndError("Aborting")
                 end
             elseif typeof(e1) == GetField && typeof(e2) == GetField && (haskey(unknowns, e1.name) || haskey(unknowns, e2.name))
                 println("One is unknown:")

--- a/src/symbolic/Tearing.jl
+++ b/src/symbolic/Tearing.jl
@@ -104,13 +104,13 @@ function initAlgebraicSystem(td::TraverseDAG, es::Vector{Int}, vs::Vector{Int},
     # check arguments
     for i in eachindex(es)
         if es[i] <= 0
-            error("\n\n... Internal error in Tearing.jl: es[", i, "] = ", es[i], ".\n")
+            ModiaLogging.closeLogModiaAndError("\n\n... Internal error in Tearing.jl: es[", i, "] = ", es[i], ".\n")
         end
     end
 
     for i in eachindex(vs)
         if vs[i] <= 0
-            error("\n\n... Internal error in Tearing.jl: vs[", i, "] = ", vs[i], ".\n")       
+            ModiaLogging.closeLogModiaAndError("\n\n... Internal error in Tearing.jl: vs[", i, "] = ", vs[i], ".\n")       
         end
     end 
 
@@ -251,7 +251,7 @@ function visit2!(td::TraverseDAG, vVisit::Int)
                         if !td.visited[eq2]   # visit eq2 if not yet visited
                             push!(td.stack, v)
                         elseif td.check[eq2]  # cycle detected
-                            error("... error in Tearing.jl code: \n",
+                            ModiaLogging.closeLogModiaAndError("... error in Tearing.jl code: \n",
                            "    cycle detected (should not occur): eq = ", eq, ", veq = ", veq, ", eq2 = ", eq2, ", v = ", v)
                         end
                     end

--- a/src/symbolic/Utilities.jl
+++ b/src/symbolic/Utilities.jl
@@ -103,7 +103,7 @@ function showModel(mod, indent="")
                         # mod.partial = true
                     end
                 else
-                    error("Missing parentheses in extends clause: @extends $(mod.initializers[i].fdef.args[2].args[2].args[2])")
+                    ModiaLogging.closeLogModiaAndError("Missing parentheses in extends clause: @extends $(mod.initializers[i].fdef.args[2].args[2].args[2])")
                 end
             end
         end
@@ -230,7 +230,7 @@ function checkSizes(VSizes, ESizes)
     if length(VSizes) != length(ESizes)
         ModiaLogging.increaseLogCategory(:UnbalancedModel)
         # For TestArray5
-        #    error("The number of unknowns ($(length(VSizes))) is not equal to the number of equations ($(length(ESizes)))")
+        #    ModiaLogging.closeLogModiaAndError("The number of unknowns ($(length(VSizes))) is not equal to the number of equations ($(length(ESizes)))")
     end
 
     loglnModia()
@@ -239,9 +239,10 @@ function checkSizes(VSizes, ESizes)
     scalarE = sum(length(zeros(e)) for e in ESizes)
     
     if scalarV != scalarE  
-        # error("Scalarized system matrix is not square: $scalarE x $scalarV")
+        # ModiaLogging.closeLogModiaAndError("Scalarized system matrix is not square: $scalarE x $scalarV")
         ModiaLogging.closeLogModia()
-        error("The number of scalarized unknowns (= $scalarV) is not equal to the number of scalarized equations (= $scalarE).\n",
+        ModiaLogging.closeLogModiaAndError(
+              "The number of scalarized unknowns (= $scalarV) is not equal to the number of scalarized equations (= $scalarE).\n",
               "If option `simulate(<model>, ...; logTranslation=true)` is set, inspect <user>/ModiaResults/<model>.txt for more info.")
         ok = false
     else
@@ -258,7 +259,7 @@ function checkSizes(VSizes, ESizes)
         ESizeCount = [length([s for s in ESizes if s == d ]) for d in differentESizes]
         @show differentVSizes VSizeCount differentESizes ESizeCount
         ok = false
-        error("The sizes of variables and equations don't match.")
+        ModiaLogging.closeLogModiaAndError("The sizes of variables and equations don't match.")
     end
 end
 


### PR DESCRIPTION
On my system, I usually get blank log files (`~/ModiaResults/*`). Closing the log file helps. This patch attempts to hit all locations where this could happen as a result of calls to `error`.